### PR TITLE
generate synthetic images at multiple objectives

### DIFF
--- a/SyMBac/PSF.py
+++ b/SyMBac/PSF.py
@@ -142,6 +142,7 @@ class PSF_generator:
             ax.imshow(self.kernel, cmap="Greys_r")
             scalebar = ScaleBar(self.scale, "um", length_fraction=0.25)
             ax.add_artist(scalebar)
+            ax.set_title(f"apo_sigma: {self.apo_sigma}")
             plt.show()
 
     @staticmethod

--- a/SyMBac/drawing.py
+++ b/SyMBac/drawing.py
@@ -111,18 +111,18 @@ def raster_cell(length, width, separation, pinching=True, FL = False):
     new_cell = np.zeros((L, W))
     R = (W - 1) / 2
 
-    x_cyl = np.arange(0, 2 * R + 1, 1)
+    x_cyl = np.arange(2 * R + 1)
     I_cyl = np.sqrt(R ** 2 - (x_cyl - R) ** 2)
     L_cyl = L - W
     new_cell[int(W / 2):-int(W / 2), :] = I_cyl
 
-    x_sphere = np.arange(0, int(W / 2), 1)
+    x_sphere = np.arange(int(W / 2))
     sphere_Rs = np.sqrt((R) ** 2 - (x_sphere - R) ** 2)
     sphere_Rs = np.rint(sphere_Rs).astype(int)
 
     for c in range(len(sphere_Rs)):
         R_ = sphere_Rs[c]
-        x_cyl = np.arange(0, R_, 1)
+        x_cyl = np.arange(R_)
         I_cyl = np.sqrt(R_ ** 2 - (x_cyl - R_) ** 2)
         new_cell[c, int(W / 2) - sphere_Rs[c]:int(W / 2) + sphere_Rs[c]] = np.concatenate((I_cyl, I_cyl[::-1]))
         new_cell[L - c - 1, int(W / 2) - sphere_Rs[c]:int(W / 2) + sphere_Rs[c]] = np.concatenate((I_cyl, I_cyl[::-1]))
@@ -132,7 +132,7 @@ def raster_cell(length, width, separation, pinching=True, FL = False):
         new_cell[int((L - S) / 2) + 1:-int((L - S) / 2) - 1, :] = 0
         for c in range(int((S+1) / 2)):
             R__ = sphere_Rs[-c - 1]
-            x_cyl_ = np.arange(0, R__, 1)
+            x_cyl_ = np.arange(R__)
             I_cyl_ = np.sqrt(R__ ** 2 - (x_cyl_ - R__) ** 2)
             new_cell[int((L-S) / 2) + c + 1, int(W / 2) - R__:int(W / 2) + R__] = np.concatenate((I_cyl_, I_cyl_[::-1]))
             new_cell[-int((L-S) / 2) - c - 1, int(W / 2) - R__:int(W / 2) + R__] = np.concatenate((I_cyl_, I_cyl_[::-1]))

--- a/SyMBac/simulation.py
+++ b/SyMBac/simulation.py
@@ -36,7 +36,7 @@ class Simulation:
 
     """
 
-    def __init__(self, trench_length, trench_width, cell_max_length, max_length_var, cell_width, width_var, lysis_p, sim_length, pix_mic_conv, gravity, phys_iters, resize_amount, save_dir):
+    def __init__(self, trench_length, trench_width, cell_max_length, max_length_var, cell_width, width_var, lysis_p, sim_length, pix_mic_conv, gravity, phys_iters, resize_amount, save_dir, objective):
         """
         Initialising a Simulation object
 
@@ -72,6 +72,8 @@ class Simulation:
         resize_amount : int
             This is the "upscaling" factor for the simulation and the entire image generation process. Must be kept constant
             across the image generation pipeline. Starting value of 3 recommended.
+        objective : int
+            The objective magnification of the images you are trying to replicate
         """
         self.trench_length = trench_length
         self.trench_width = trench_width
@@ -87,6 +89,7 @@ class Simulation:
         self.resize_amount = resize_amount
         self.save_dir = save_dir
         self.offset = 30
+        self.objective = objective
 
     def run_simulation(self, show_window = True):
         """

--- a/tests/test_phase_contrast_drawing.py
+++ b/tests/test_phase_contrast_drawing.py
@@ -73,7 +73,7 @@ class TestExample(unittest.TestCase):
             mask=scenes[0][1],
             media_multiplier=media_multiplier,
             cell_multiplier=cell_multiplier,
-            device_multiplier=cell_multiplier,
+            device_multiplier=device_multiplier,
             y_border_expansion_coefficient=y_border_expansion_coefficient,
             x_border_expansion_coefficient=x_border_expansion_coefficient,
             fluorescence=False,


### PR DESCRIPTION
- main changes in renderer.py: can input lists of PSFs and real_images
- can optimise each set of images separately
- will generate data from the same scene at different objectives
- can use these images to train superresolution networks
- behaviour should be unchanged with just one PSF/real image input
- misc.py has two new functions added for use in renderer.py
- a few other minor edits