### PR TITLE
Prevent instance labels wrapping during mask export

### DIFF
--- a/SyMBac/renderer.py
+++ b/SyMBac/renderer.py
@@ -82,6 +82,26 @@ def _convolve_2d(image, kernel):
         return _fftconvolve(image, kernel, mode="same")
 
 
+def _relabel_instance_masks(mask, superres_mask, mask_dtype):
+    mask_dtype = np.dtype(mask_dtype)
+    labels = np.union1d(np.unique(mask), np.unique(superres_mask))
+    labels = labels[labels != 0]
+
+    if len(labels) > np.iinfo(mask_dtype).max:
+        raise ValueError(
+            f"{len(labels)} instances cannot be represented by {mask_dtype.name}"
+        )
+
+    relabeled_masks = []
+    for source_mask in (mask, superres_mask):
+        relabeled_mask = np.zeros(source_mask.shape, dtype=mask_dtype)
+        for new_label, old_label in enumerate(labels, start=1):
+            relabeled_mask[source_mask == old_label] = new_label
+        relabeled_masks.append(relabeled_mask)
+
+    return relabeled_masks
+
+
 def convolve_rescale(image, kernel, rescale_factor, rescale_int):
     """
     Convolves an image with a kernel, and rescales it to the correct size.
@@ -1155,10 +1175,15 @@ class Renderer:
                 superres_mask = Image.fromarray(superres_mask.astype(mask_dtype))
                 superres_mask.save("{}/superres_masks/{}synth_{}.png".format(save_dir, str(z).zfill(5)))
             else:
-                mask = Image.fromarray(mask.astype(mask_dtype))
+                mask, superres_mask = _relabel_instance_masks(
+                    mask,
+                    superres_mask,
+                    mask_dtype,
+                )
+                mask = Image.fromarray(mask)
                 mask.save("{}/masks/{}synth_{}.png".format(save_dir, prefix, str(z).zfill(5)))
 
-                superres_mask = Image.fromarray(superres_mask.astype(mask_dtype))
+                superres_mask = Image.fromarray(superres_mask)
                 superres_mask.save("{}/superres_masks/{}synth_{}.png".format(save_dir, prefix, str(z).zfill(5)))
 
 

--- a/tests/test_renderer_mask_export.py
+++ b/tests/test_renderer_mask_export.py
@@ -1,0 +1,112 @@
+from types import MethodType, SimpleNamespace
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from SyMBac.renderer import Renderer
+
+
+def _renderer_returning(mask, superres_mask):
+    renderer = Renderer.__new__(Renderer)
+    renderer.additional_real_images = []
+    renderer.params = SimpleNamespace(
+        kwargs={
+            "noise_var": 0.0,
+            "defocus": 0.0,
+            "halo_top_intensity": 0.0,
+            "halo_bottom_intensity": 0.0,
+            "halo_start": 0.0,
+            "halo_end": 0.0,
+            "cell_texture_strength": 0.0,
+            "cell_texture_scale": 1.0,
+        }
+    )
+
+    def generate_test_comparison(self, **kwargs):
+        image = np.arange(mask.size, dtype=float).reshape(mask.shape)
+        return image, mask.copy(), superres_mask.copy()
+
+    renderer.generate_test_comparison = MethodType(
+        generate_test_comparison,
+        renderer,
+    )
+    return renderer
+
+
+def _render_parameters():
+    return {
+        "n_samples": 1,
+        "media_multipliers": [1.0],
+        "cell_multipliers": [1.0],
+        "device_multipliers": [1.0],
+        "sigmas": [1.0],
+        "scene_nos": [0],
+        "hist_match_bools": [False],
+        "noise_match_bools": [False],
+        "fourier_match_bools": [False],
+    }
+
+
+def test_generate_training_data_relabels_instances_before_uint8_export(tmp_path):
+    mask = np.array(
+        [
+            [0, 255, 256, 512],
+            [768, 0, 0, 0],
+        ],
+        dtype=np.uint16,
+    )
+    superres_mask = np.array(
+        [
+            [768, 512, 256, 255],
+            [0, 0, 0, 0],
+        ],
+        dtype=np.uint16,
+    )
+    renderer = _renderer_returning(mask, superres_mask)
+
+    with pytest.warns(UserWarning, match="render_sample_parameters"):
+        renderer.generate_training_data(
+            sample_amount=0,
+            randomise_hist_match=False,
+            randomise_noise_match=False,
+            burn_in=0,
+            n_samples=1,
+            save_dir=str(tmp_path),
+            n_jobs=1,
+            mask_dtype=np.uint8,
+            render_sample_parameters=_render_parameters(),
+        )
+
+    saved_mask = np.asarray(Image.open(tmp_path / "masks" / "Nonesynth_00000.png"))
+    saved_superres_mask = np.asarray(
+        Image.open(tmp_path / "superres_masks" / "Nonesynth_00000.png")
+    )
+
+    assert np.array_equal(
+        saved_mask,
+        np.array([[0, 1, 2, 3], [4, 0, 0, 0]], dtype=np.uint8),
+    )
+    assert np.array_equal(
+        saved_superres_mask,
+        np.array([[4, 3, 2, 1], [0, 0, 0, 0]], dtype=np.uint8),
+    )
+
+
+def test_generate_training_data_rejects_more_instances_than_dtype_can_store(tmp_path):
+    mask = np.arange(1, 257, dtype=np.uint16).reshape(16, 16)
+    renderer = _renderer_returning(mask, mask)
+
+    with pytest.warns(UserWarning, match="render_sample_parameters"):
+        with pytest.raises(ValueError, match="256 instances.*uint8"):
+            renderer.generate_training_data(
+                sample_amount=0,
+                randomise_hist_match=False,
+                randomise_noise_match=False,
+                burn_in=0,
+                n_samples=1,
+                save_dir=str(tmp_path),
+                n_jobs=1,
+                mask_dtype=np.uint8,
+                render_sample_parameters=_render_parameters(),
+            )


### PR DESCRIPTION
## What changed

- Relabel independent training-image masks to consecutive per-frame instance IDs before converting to the requested storage dtype.
- Apply the same mapping to the normal and super-resolution masks.
- Raise a clear error if a frame contains more instances than the requested dtype can represent.
- Add regression tests for wrapped lineage IDs and dtype capacity.

## Why

`generate_training_data` defaults to `uint8`, but previously cast the simulation's persistent lineage IDs directly. IDs such as 256, 512, and 768 therefore became background label 0, silently removing visible cells from exported ground-truth masks.

Independent segmentation-training images only require unique instance IDs within each frame, so dense per-frame relabelling preserves the intended mask semantics while retaining compact `uint8` output.

The time-series export path is unchanged because persistent IDs are meaningful there.

## Validation

- `pixi run pytest -q`: 63 passed
- The regression test confirms that source IDs 255, 256, 512, and 768 are exported as nonzero instance IDs 1 through 4 with matching IDs in the normal and super-resolution masks.
- A second test confirms that 256 instances requested as `uint8` raise instead of wrapping.
