### PR TITLE
Fix trench boundary handling and image cropping

### DIFF
--- a/SyMBac/drawing.py
+++ b/SyMBac/drawing.py
@@ -11,7 +11,6 @@ from skimage.exposure import rescale_intensity
 from skimage.segmentation import find_boundaries
 from PIL import Image
 
-div_odd = lambda n: (n // 2, n // 2 + 1)
 perc_diff = lambda a, b: (a - b) / b * 100
 
 
@@ -64,7 +63,8 @@ def apply_cell_texture(OPL_cell, cell_id, scale=70.0, octaves=3, persistence=0.5
 def get_crop_bounds_2D(img, tol=0):
     mask = img>tol
     x_idx = np.ix_(mask.any(1),mask.any(0))
-    start_row, stop_row, start_col, stop_col = x_idx[0][0][0], x_idx[0][-1][0], x_idx[1][0][0], x_idx[1][0][-1]
+    start_row, stop_row = x_idx[0][0][0], x_idx[0][-1][0] + 1
+    start_col, stop_col = x_idx[1][0][0], x_idx[1][0][-1] + 1
 
     return (start_row, stop_row), (start_col, stop_col)
 
@@ -334,34 +334,14 @@ def make_images_same_shape(real_image, synthetic_image, rescale_int=True):
         1], "Real image has a higher diemsion on axis 1, increase x_border_expansion_coefficient"
 
     x_diff = synthetic_image.shape[1] - real_image.shape[1]
-    remove_from_left, remove_from_right = div_odd(x_diff)
+    x_start = x_diff // 2
+    x_stop = x_start + real_image.shape[1]
     y_diff = synthetic_image.shape[0] - real_image.shape[0]
-    if real_image.shape[1] % 2 == 0:
-        if synthetic_image.shape[1] % 2 == 0:
-            if y_diff > 0:
-                synthetic_image = synthetic_image[y_diff:, remove_from_left - 1:-remove_from_right]
-            else:
-                synthetic_image = synthetic_image[:, remove_from_left:-remove_from_right]
-                real_image = real_image[abs(y_diff):, :]
-        elif synthetic_image.shape[1] % 2 == 1:
-            if y_diff > 0:
-                synthetic_image = synthetic_image[y_diff:, remove_from_left:-remove_from_right]
-            else:
-                synthetic_image = synthetic_image[:, remove_from_left:-remove_from_right]
-                real_image = real_image[abs(y_diff):, :]
-    elif real_image.shape[1] % 2 == 1:
-        if synthetic_image.shape[1] % 2 == 0:
-            if y_diff > 0:
-                synthetic_image = synthetic_image[y_diff:, remove_from_left:-remove_from_right]
-            else:
-                synthetic_image = synthetic_image[:, remove_from_left:-remove_from_right]
-                real_image = real_image[abs(y_diff):, :]
-        elif synthetic_image.shape[1] % 2 == 1:
-            if y_diff > 0:
-                synthetic_image = synthetic_image[y_diff:, remove_from_left - 1:-remove_from_right]
-            else:
-                synthetic_image = synthetic_image[:, remove_from_left:-remove_from_right]
-                real_image = real_image[abs(y_diff):, :]
+    if y_diff > 0:
+        synthetic_image = synthetic_image[y_diff:, x_start:x_stop]
+    else:
+        synthetic_image = synthetic_image[:, x_start:x_stop]
+        real_image = real_image[abs(y_diff):, :]
 
     if rescale_int:
         real_image = rescale_intensity(real_image.astype(np.float32), out_range=(0, 1))

--- a/SyMBac/physics/microfluidic_geometry.py
+++ b/SyMBac/physics/microfluidic_geometry.py
@@ -35,12 +35,14 @@ class SegmentPrimitive:
     p1: tuple[float, float]
     p2: tuple[float, float]
     thickness: float
+    geometry_role: str | None = None
 
     def translated(self, dx: float, dy: float) -> "SegmentPrimitive":
         return SegmentPrimitive(
             p1=(self.p1[0] + dx, self.p1[1] + dy),
             p2=(self.p2[0] + dx, self.p2[1] + dy),
             thickness=self.thickness,
+            geometry_role=self.geometry_role,
         )
 
 
@@ -136,6 +138,8 @@ def segment_creator(local_xy1, local_xy2, global_xy, thickness):
 
 def _add_world_segment(space: pymunk.Space, primitive: SegmentPrimitive) -> None:
     body, shape = segment_creator(primitive.p1, primitive.p2, (0.0, 0.0), primitive.thickness)
+    if primitive.geometry_role is not None:
+        shape.geometry_role = primitive.geometry_role
     space.add(body, shape)
 
 
@@ -219,6 +223,7 @@ class TrenchGeometrySpec(GeometrySpec):
                     p1=(global_offset_x + x1, global_offset_y + y1),
                     p2=(global_offset_x + x2, global_offset_y + y2),
                     thickness=self.barrier_thickness,
+                    geometry_role="trench_cap",
                 )
             )
 
@@ -228,11 +233,13 @@ class TrenchGeometrySpec(GeometrySpec):
                     p1=(-self.width / 2.0 - self.barrier_thickness, self.width / 2.0),
                     p2=(-self.width / 2.0 - self.barrier_thickness, self.width / 2.0 + self.trench_length),
                     thickness=self.barrier_thickness,
+                    geometry_role="trench_wall",
                 ),
                 SegmentPrimitive(
                     p1=(self.width / 2.0 + self.barrier_thickness, self.width / 2.0),
                     p2=(self.width / 2.0 + self.barrier_thickness, self.width / 2.0 + self.trench_length),
                     thickness=self.barrier_thickness,
+                    geometry_role="trench_wall",
                 ),
             ]
         )
@@ -257,6 +264,10 @@ class TrenchGeometrySpec(GeometrySpec):
     def seed_cell_local_position(self, segment_radius: float) -> tuple[float, float]:
         return (0.0, self.width / 2.0 + segment_radius * 3.0)
 
+    def _minimum_center_y(self, x: float, radius: float) -> float:
+        usable_cap_radius = self.inner_half_width - radius
+        return self.inner_half_width - np.sqrt(max(usable_cap_radius**2 - x**2, 0.0))
+
     def positions_within_bounds(
         self,
         positions,
@@ -274,7 +285,7 @@ class TrenchGeometrySpec(GeometrySpec):
                 return False
             if x > (self.inner_half_width - radius):
                 return False
-            if y < (0.25 * radius):
+            if y < self._minimum_center_y(x, radius):
                 return False
             if enforce_open_end_cap and y > (self.open_end_y - 0.25 * radius):
                 return False
@@ -295,10 +306,9 @@ class TrenchGeometrySpec(GeometrySpec):
         local_position = layout.to_local_point((float(body.position[0]), float(body.position[1])))
         min_x = -self.inner_half_width + radius
         max_x = self.inner_half_width - radius
-        min_y = 0.25 * radius
 
         clamped_x = min(max(local_position[0], min_x), max_x)
-        clamped_y = max(local_position[1], min_y)
+        clamped_y = max(local_position[1], self._minimum_center_y(clamped_x, radius))
         changed_x = clamped_x != local_position[0]
         changed_y = clamped_y != local_position[1]
         projected = changed_x or changed_y

--- a/SyMBac/trench_geometry.py
+++ b/SyMBac/trench_geometry.py
@@ -27,6 +27,8 @@ def trench_creator(size,trench_length, global_xy, space):
     barrier_thickness = 10
     left_barrier = segment_creator((0,0),(0,trench_length),(global_xy[0]-barrier_thickness, global_xy[1]),barrier_thickness)
     right_barrier = segment_creator((size,0),(size,trench_length),(global_xy[0]+size/2+barrier_thickness, global_xy[1]),barrier_thickness)
+    left_barrier[1].geometry_role = "trench_wall"
+    right_barrier[1].geometry_role = "trench_wall"
     walls = [left_wall, right_wall, left_barrier, right_barrier]
     for z in walls:
         for s in z:
@@ -42,10 +44,12 @@ def get_trench_segments(space):
     -------
     List of trench segment properties, later used to draw the trench.
     """
-    trench_shapes = []
-    for shape, body in zip(space.shapes, space.bodies):
-        if body.body_type == 2:
-            trench_shapes.append(shape)
+    trench_shapes = [
+        shape
+        for shape in space.shapes
+        if shape.body.body_type == pymunk.Body.STATIC
+        and getattr(shape, "geometry_role", None) == "trench_wall"
+    ]
 
     trench_segment_props = []
     for x in trench_shapes:
@@ -53,5 +57,4 @@ def get_trench_segments(space):
 
     trench_segment_props = pd.DataFrame(trench_segment_props)
     trench_segment_props.columns = ["bb", "area", "a", "b"]
-    main_segments = trench_segment_props.sort_values("area", ascending=False).iloc[0:2]
-    return main_segments
+    return trench_segment_props

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from SyMBac.drawing import crop_image, get_crop_bounds_2D, make_images_same_shape
+
+
+@pytest.mark.parametrize(
+    ("region", "expected_shape"),
+    [
+        ((slice(2, 3), slice(4, 5)), (1, 1)),
+        ((slice(1, 5), slice(2, 6)), (4, 4)),
+    ],
+)
+def test_crop_bounds_use_exclusive_stop_indices(region, expected_shape):
+    image = np.zeros((7, 8), dtype=np.uint8)
+    image[region] = 1
+
+    rows, cols = get_crop_bounds_2D(image)
+    cropped = crop_image(image, rows, cols, pad=0)
+
+    assert cropped.shape == expected_shape
+    assert np.all(cropped == 1)
+
+
+@pytest.mark.parametrize(("real_width", "synthetic_width"), [(4, 8), (5, 9)])
+def test_make_images_same_shape_centers_same_parity_widths(real_width, synthetic_width):
+    real_image = np.zeros((2, real_width))
+    synthetic_image = np.tile(np.arange(synthetic_width), (4, 1))
+
+    _, cropped = make_images_same_shape(real_image, synthetic_image, rescale_int=False)
+
+    expected_start = (synthetic_width - real_width) // 2
+    expected = synthetic_image[2:, expected_start : expected_start + real_width]
+    np.testing.assert_array_equal(cropped, expected)

--- a/tests/test_microfluidic_geometry.py
+++ b/tests/test_microfluidic_geometry.py
@@ -1,6 +1,14 @@
+import numpy as np
+import pymunk
 import pytest
 
 from SyMBac.physics.microfluidic_geometry import GeometryLayout, TrenchGeometrySpec
+
+
+@pytest.fixture
+def trench_geometry():
+    geometry = TrenchGeometrySpec(width=18.0, trench_length=39.0, barrier_thickness=10.0)
+    return geometry, GeometryLayout(geometry, min_preview_size=0)
 
 
 def test_geometry_layout_offsets_trench_into_positive_padded_world_bounds():
@@ -13,3 +21,43 @@ def test_geometry_layout_offsets_trench_into_positive_padded_world_bounds():
     assert layout.world_bounds.max_y > layout.world_bounds.min_y
     assert layout.preview_shape[0] >= int(layout.world_bounds.max_y)
     assert layout.preview_shape[1] >= int(layout.world_bounds.max_x)
+
+
+@pytest.mark.parametrize(
+    ("local_position", "expected"),
+    [
+        ((0.0, 1.9), False),
+        ((0.0, 2.0), True),
+        ((6.0, 5.0), False),
+        ((6.0, 5.5), True),
+    ],
+)
+def test_trench_containment_follows_rounded_cap(trench_geometry, local_position, expected):
+    geometry, layout = trench_geometry
+    positions = np.array([layout.to_world_point(local_position)])
+
+    result = geometry.positions_within_bounds(
+        positions,
+        radii=[2.0],
+        layout=layout,
+        enforce_open_end_cap=False,
+    )
+
+    assert result is expected
+
+
+def test_trench_projection_moves_cells_clear_of_rounded_cap(trench_geometry):
+    geometry, layout = trench_geometry
+    body = pymunk.Body(1.0, 1.0)
+    body.position = layout.to_world_point((6.0, 5.0))
+    body.velocity = (1.0, -2.0)
+
+    projected, changed_x, changed_y = geometry.project_body_inside_bounds(body, radius=2.0, layout=layout)
+
+    expected_y = geometry.inner_half_width - np.sqrt((geometry.inner_half_width - 2.0) ** 2 - 6.0**2)
+    local_position = layout.to_local_point(body.position)
+    assert projected
+    assert not changed_x
+    assert changed_y
+    assert local_position == pytest.approx((6.0, expected_y))
+    assert body.velocity == pytest.approx((1.0, 0.0))

--- a/tests/test_trench_geometry.py
+++ b/tests/test_trench_geometry.py
@@ -1,0 +1,49 @@
+import pymunk
+import pytest
+
+from SyMBac.physics.microfluidic_geometry import GeometryLayout, TrenchGeometrySpec
+from SyMBac.trench_geometry import get_trench_segments, trench_creator
+
+
+@pytest.mark.parametrize("trench_length", [4.0, 10.0])
+def test_get_trench_segments_finds_walls_in_short_trenches(trench_length):
+    geometry = TrenchGeometrySpec(width=18.0, trench_length=trench_length, barrier_thickness=10.0)
+    layout = GeometryLayout(geometry, min_preview_size=0)
+    space = pymunk.Space()
+    geometry.build(space, layout)
+
+    unrelated_body = pymunk.Body(body_type=pymunk.Body.STATIC)
+    unrelated_shape = pymunk.Segment(unrelated_body, (-100.0, 0.0), (-100.0, 100.0), 20.0)
+    space.add(unrelated_body, unrelated_shape)
+
+    walls = get_trench_segments(space)
+
+    assert len(walls) == 2
+    wall_lengths = sorted(abs(float(row.b.y - row.a.y)) for row in walls.itertuples())
+    assert wall_lengths == pytest.approx([trench_length, trench_length])
+
+
+def test_get_trench_segments_uses_each_shapes_body():
+    space = pymunk.Space()
+    space.add(pymunk.Body(1.0, 1.0))
+
+    for x in (0.0, 10.0):
+        body = pymunk.Body(body_type=pymunk.Body.STATIC)
+        shape = pymunk.Segment(body, (x, 0.0), (x, 4.0), 1.0)
+        shape.geometry_role = "trench_wall"
+        space.add(body, shape)
+
+    walls = get_trench_segments(space)
+
+    assert len(walls) == 2
+
+
+def test_legacy_trench_creator_marks_short_trench_walls():
+    space = pymunk.Space()
+    trench_creator(size=18.0, trench_length=4.0, global_xy=(0.0, 0.0), space=space)
+
+    walls = get_trench_segments(space)
+
+    assert len(walls) == 2
+    wall_lengths = sorted(abs(float(row.b.y - row.a.y)) for row in walls.itertuples())
+    assert wall_lengths == pytest.approx([4.0, 4.0])


### PR DESCRIPTION
## What changed

- Constrain and project cell centers against the rounded U-shaped trench cap instead of a flat rectangular floor.
- Mark trench walls explicitly and extract them through each shape body relationship, so cap segments, unrelated static geometry, and short walls are not mistaken for one another.
- Return exclusive crop stop indices and center same-parity horizontal crops without a one-pixel shift.
- Add small parameterized geometry and crop regressions; no visual snapshot tests were added.

## Why

The previous containment floor did not follow the cap curve, so cells could overlap the closed end. Trench wall extraction zipped independent Pymunk collections and then assumed the two largest static shapes were the walls, which fails for short trenches and additional static geometry. Crop bounds mixed inclusive maxima with Python exclusive slices, and same-parity width handling shifted centered crops left by one pixel.

## Validation

- `pixi run pytest tests/test_drawing.py tests/test_microfluidic_geometry.py tests/test_trench_geometry.py tests/test_simulation_persistence.py tests/test_renderer_mask_export.py -q` — 30 passed, 1 existing CPU-fallback warning
- `pixi run pytest` — 76 passed, 1 existing CPU-fallback warning