### PR TITLE
Fix image matching and mask helper correctness

### DIFF
--- a/SyMBac/misc.py
+++ b/SyMBac/misc.py
@@ -19,11 +19,16 @@ def resize_mask(mask, resize_shape, ret_label):
     :return: Resized mask
     :rtype: np.ndarray
     """
-    labeled_mask = label(mask > 0, connectivity=1)
+    preserve_labels = np.issubdtype(mask.dtype, np.integer) and np.any(mask > 1)
+    if preserve_labels:
+        labeled_mask = mask
+    else:
+        labeled_mask = label(mask > 0, connectivity=1)
     labeled_mask = resize(labeled_mask, resize_shape, order=0, mode='reflect', cval=0, clip=True, preserve_range=True,
                           anti_aliasing=False, anti_aliasing_sigma=None).astype(int)
-    mask_borders = find_boundaries(labeled_mask, mode="thick", connectivity=1)
-    labeled_mask = np.where(mask_borders, 0, labeled_mask)
+    if not preserve_labels:
+        mask_borders = find_boundaries(labeled_mask, mode="thick", connectivity=1)
+        labeled_mask = np.where(mask_borders, 0, labeled_mask)
     if ret_label:
         return labeled_mask
     else:
@@ -123,9 +128,9 @@ def unet_weight_map(y, wc=None, w0=10, sigma=5):
         d2 = distances[:, :, 1]
         w = w0 * np.exp(-1 / 2 * ((d1 + d2) / sigma) ** 2) * no_labels
     else:
-        w = np.zeros_like(y)
+        w = np.zeros(y.shape, dtype=float)
     if wc:
-        class_weights = np.zeros_like(y)
+        class_weights = np.zeros(y.shape, dtype=float)
         for k, v in wc.items():
             class_weights[y == k] = v
         w = w + class_weights

--- a/SyMBac/pySHINE.py
+++ b/SyMBac/pySHINE.py
@@ -53,19 +53,32 @@ def sfMatch(images, rescaling=0, tarmag=None):
         r = np.round(r) - 1
     else:
         r = np.round(r)
+    radial_bins = (r.T.ravel() + 1).astype(int)
+    _, radial_inverse = np.unique(radial_bins, return_inverse=True)
+    number_of_bins = radial_inverse.max() + 1
+    target_energy = np.bincount(
+        radial_inverse,
+        weights=tarmag.T.ravel(),
+        minlength=number_of_bins,
+    )
+    coefficient_indices = r.astype(int)
+    outside_radius = r > np.floor(np.max((xs, ys)) / 2)
     output_images = []
     for x in range(numin):
         fftim = mags[:, :, x]
-        a = fftim.T.ravel()
-        accmap = r.T.ravel() + 1
-        a2 = tarmag.T.ravel()
-        en_old = np.array(
-            [np.sum([a[x] for x in y]) for y in [list(np.where(accmap == z)) for z in np.unique(accmap).tolist()]])
-        en_new = np.array(
-            [np.sum([a2[x] for x in y]) for y in [list(np.where(accmap == z)) for z in np.unique(accmap).tolist()]])
-        coefficient = en_new / en_old
-        cmat = coefficient[(r).astype(int)]  # coefficient[r+1]
-        cmat[r > np.floor(np.max((xs, ys)) / 2)] = 0
+        source_energy = np.bincount(
+            radial_inverse,
+            weights=fftim.T.ravel(),
+            minlength=number_of_bins,
+        )
+        coefficient = np.divide(
+            target_energy,
+            source_energy,
+            out=np.zeros_like(target_energy),
+            where=source_energy != 0,
+        )
+        cmat = coefficient[coefficient_indices]
+        cmat[outside_radius] = 0
         newmag = fftim * cmat
         XX, YY = pol2cart(angs[:, :, x], newmag)
         new = XX + YY * complex(0, 1)
@@ -144,15 +157,11 @@ def lumMatch(images, mask=None, lum=None):
                 im1[:, :] = M
             output_images.append(im1)
     elif (mask is None) and (lum is not None):
-        M = 0
-        S = 0
         for im in range(numin):
             if len(images[im].shape) == 3:
                 images[im] = rgb2gray(images[im])
-            M = lum[0]
-            S = lum[1]
-        M = M / numin
-        S = S / numin
+        M = lum[0]
+        S = lum[1]
         output_images = []
         for im in range(numin):
             im1 = copy.deepcopy(images[im])
@@ -173,7 +182,7 @@ def lumMatch(images, mask=None, lum=None):
             assert m.size == images[im].size, "Image and mask are not the same size"
             assert np.sum(m == 1) > 0, 'The mask must contain some ones.'
             M = M + np.mean(im1[m == 1])
-            S = S + np.mean(im1[m == 1])
+            S = S + np.std(im1[m == 1])
         M = M / numin
         S = S / numin
         output_images = []

--- a/tests/test_image_helpers.py
+++ b/tests/test_image_helpers.py
@@ -1,0 +1,77 @@
+import numpy as np
+
+from SyMBac.pySHINE import lumMatch, sfMatch
+
+
+def test_lum_match_does_not_average_explicit_luminance_over_images():
+    images = [
+        np.array([[0.0, 1.0], [2.0, 3.0]]),
+        np.array([[4.0, 6.0], [8.0, 10.0]]),
+    ]
+
+    matched = lumMatch(images, lum=(10, 2))
+
+    for image in matched:
+        np.testing.assert_allclose((np.mean(image), np.std(image)), (10, 2))
+
+
+def test_lum_match_infers_masked_mean_and_standard_deviation():
+    images = [
+        np.array([[0.0, 2.0], [0.0, 2.0]]),
+        np.array([[10.0, 14.0], [10.0, 14.0]]),
+    ]
+    masks = [np.ones((2, 2), dtype=bool) for _ in images]
+
+    matched = lumMatch(images, mask=masks)
+
+    for image in matched:
+        np.testing.assert_allclose((np.mean(image), np.std(image)), (6.5, 1.5))
+
+
+def test_sf_match_returns_finite_images_for_zero_radial_energy():
+    images = [np.zeros((8, 8)), np.full((8, 8), 42.0)]
+
+    matched = sfMatch(images)
+
+    assert all(np.isfinite(image).all() for image in matched)
+
+
+def test_sf_match_preserves_existing_nondegenerate_result():
+    images = [
+        np.array(
+            [
+                [207.0, 22.0, 46.0, 61.0],
+                [47.0, 205.0, 222.0, 149.0],
+                [11.0, 25.0, 85.0, 111.0],
+                [159.0, 123.0, 68.0, 41.0],
+            ]
+        ),
+        np.array(
+            [
+                [177.0, 188.0, 9.0, 29.0],
+                [116.0, 100.0, 227.0, 132.0],
+                [108.0, 110.0, 170.0, 150.0],
+                [45.0, 189.0, 193.0, 244.0],
+            ]
+        ),
+    ]
+    expected = np.array(
+        [
+            [
+                [215.92342446, 45.20166264, 55.74891053, 88.05443828],
+                [76.06261371, 217.33796077, 249.89337633, 157.90259746],
+                [20.89496420, 51.96898037, 89.95033884, 140.66773372],
+                [188.01957864, 134.64438587, 102.38161631, 49.84741786],
+            ],
+            [
+                [153.57458860, 173.64724241, -12.36475379, 14.15291499],
+                [100.71720676, 78.32035547, 208.18471222, 107.53532694],
+                [81.93388727, 94.49215378, 151.93353598, 139.13634474],
+                [33.24825836, 164.25409447, 178.67116675, 217.06296505],
+            ],
+        ]
+    )
+
+    matched = sfMatch(images)
+
+    np.testing.assert_allclose(matched, expected, rtol=1e-8, atol=1e-8)

--- a/tests/test_image_helpers.py
+++ b/tests/test_image_helpers.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from SyMBac.misc import resize_mask, unet_weight_map
 from SyMBac.pySHINE import lumMatch, sfMatch
 
 
@@ -75,3 +76,21 @@ def test_sf_match_preserves_existing_nondegenerate_result():
     matched = sfMatch(images)
 
     np.testing.assert_allclose(matched, expected, rtol=1e-8, atol=1e-8)
+
+
+def test_resize_mask_preserves_touching_integer_labels():
+    mask = np.array([[1, 2], [1, 2]], dtype=np.uint16)
+
+    resized = resize_mask(mask, (4, 4), ret_label=True)
+
+    expected = np.repeat(np.repeat(mask, 2, axis=0), 2, axis=1)
+    np.testing.assert_array_equal(resized, expected)
+
+
+def test_unet_weight_map_preserves_fractional_class_weights():
+    mask = np.array([[0, 0, 1], [0, 1, 1]], dtype=np.uint8)
+
+    weights = unet_weight_map(mask, wc={0: 0.25, 1: 1.5})
+
+    assert np.issubdtype(weights.dtype, np.floating)
+    np.testing.assert_array_equal(weights, np.where(mask == 0, 0.25, 1.5))


### PR DESCRIPTION
## What changed

- keep explicit `lumMatch` mean and standard deviation values independent of the number of input images
- infer masked luminance spread from the masked standard deviation rather than the masked mean
- make `sfMatch` finite for zero-energy radial bins and replace repeated full-image bin scans with one vectorized bin map plus `bincount` reductions
- preserve touching integer labels during nearest-neighbor mask resizing
- allocate floating U-Net weight maps so fractional class weights are retained
- add focused numerical regressions for each failure

## Why

The helpers were losing caller-supplied luminance values, calculating one masked statistic from the wrong quantity, producing NaN/inf for constant images, merging touching instance labels, and truncating fractional weights. The Fourier implementation also repeatedly scanned every pixel once per radial bin.

## Validation

- `pixi run pytest -q tests/test_image_helpers.py tests/test_renderer_mask_export.py` — 8 passed, 1 existing CPU-fallback warning
- `pixi run pytest -q` — 69 passed, 1 existing CPU-fallback warning
- old/new `sfMatch` comparison on 4×4, 5×7, and 32×48 inputs — maximum absolute difference at most `1.421e-13`
- local full-function timing on two 256×256 images, 3 runs — median `29.7 ms` before and `15.1 ms` after (about 2× faster)

No benchmark test was added.

## Deliberately unchanged

`SyMBac/metrics.py` is only imported by `SyMBac/auto_optimise.py` in this repository. Neither file was changed because `auto_optimise.py` is scheduled for removal.