### PR TITLE
Fix growth, division, and physics invariants

### DIFF
--- a/SyMBac/physics/colony.py
+++ b/SyMBac/physics/colony.py
@@ -73,6 +73,17 @@ class Colony:
                         # If the daughter's head is overlapping with the mother
                         if info.shape in mother_shapes:
 
+                            mother_can_trim = (
+                                len(mother.physics_representation.segments)
+                                > mother.config.MIN_LENGTH_AFTER_DIVISION
+                            )
+                            daughter_can_trim = (
+                                len(daughter.physics_representation.segments)
+                                > daughter.config.MIN_LENGTH_AFTER_DIVISION
+                            )
+                            if not mother_can_trim or not daughter_can_trim:
+                                break
+
                             mother_removed_segment = mother.physics_representation.remove_tail_segment()
                             daughter_removed_segment = daughter.physics_representation.remove_head_segment()
                             if mother_removed_segment is None or daughter_removed_segment is None:

--- a/SyMBac/physics/config.py
+++ b/SyMBac/physics/config.py
@@ -103,6 +103,23 @@ class CellConfig:
 
     def __post_init__(self):
 
+        if isinstance(self.GRANULARITY, bool) or not isinstance(self.GRANULARITY, int) or self.GRANULARITY <= 0:
+            raise ValueError("GRANULARITY must be an integer greater than 0.")
+        if not np.isfinite(self.SEPTUM_DURATION) or self.SEPTUM_DURATION <= 0:
+            raise ValueError("SEPTUM_DURATION must be finite and greater than 0.")
+        if (
+            isinstance(self.MIN_LENGTH_AFTER_DIVISION, bool)
+            or not isinstance(self.MIN_LENGTH_AFTER_DIVISION, int)
+            or self.MIN_LENGTH_AFTER_DIVISION < 2
+        ):
+            raise ValueError("MIN_LENGTH_AFTER_DIVISION must be an integer of at least 2.")
+        if (
+            isinstance(self.SEED_CELL_SEGMENTS, bool)
+            or not isinstance(self.SEED_CELL_SEGMENTS, int)
+            or self.SEED_CELL_SEGMENTS < 2
+        ):
+            raise ValueError("SEED_CELL_SEGMENTS must be an integer of at least 2.")
+
         if self.MAX_LENGTH_STD < 0:
             raise ValueError("MAX_LENGTH_STD must be non-negative.")
         if self.WIDTH_STD < 0:
@@ -162,13 +179,17 @@ class PhysicsConfig:
     COLLISION_SLOP: Optional[float] = None # Amount of overlap between shapes that is allowed. To improve stability, set this as high as you can without noticeable overlapping. It defaults to 0.1.
 
     def __post_init__(self):
+        if isinstance(self.ITERATIONS, bool) or not isinstance(self.ITERATIONS, int) or self.ITERATIONS <= 0:
+            raise ValueError("ITERATIONS must be an integer greater than 0.")
+        if not np.isfinite(self.DAMPING) or not 0.0 <= self.DAMPING <= 1.0:
+            raise ValueError("DAMPING must be finite and between 0 and 1.")
         if self.THREADS > 2:
             raise ValueError("THREADS cannot be greater than 2.")
         if not self.THREADED and self.THREADS != 1:
             raise ValueError("If THREADED is False, THREADS must be 1.")
         if self.THREADED and self.THREADS != 2:
             raise ValueError("If THREADED is True, THREADS must be 2.")
-        if self.DT <= 0:
-            raise ValueError("DT must be greater than 0.")
+        if not np.isfinite(self.DT) or self.DT <= 0:
+            raise ValueError("DT must be finite and greater than 0.")
         if self.COLLISION_SLOP is not None and self.COLLISION_SLOP < 0:
             raise ValueError("COLLISION_SLOP must be non-negative when provided.")

--- a/SyMBac/physics/growth_manager.py
+++ b/SyMBac/physics/growth_manager.py
@@ -21,7 +21,11 @@ class GrowthManager:
             cell: The `SimCell` object to be grown.
             dt: The time step for the current simulation frame.
         """
-        if not cell.is_dividing and cell.length >= cell.max_length: #LENGTH_FIX # TODO: is this actually necessary?
+        enough_segments_to_divide = (
+            cell.physics_representation.num_segments
+            >= 2 * cell.config.MIN_LENGTH_AFTER_DIVISION
+        )
+        if not cell.is_dividing and cell.length >= cell.max_length and enough_segments_to_divide:
             return
 
         if cell.physics_representation.num_segments < 2:
@@ -34,28 +38,21 @@ class GrowthManager:
         cell.physics_representation.growth_accumulator_head += half_growth
         cell.physics_representation.growth_accumulator_tail += half_growth
 
-        # Stretch the head joint by adjusting the anchor on the first segment.
-        # This pushes the head segment outwards.
+        while cell.physics_representation.growth_accumulator_head >= cell.config.GROWTH_THRESHOLD:
+            cell.physics_representation.add_head_segment()
+            cell.physics_representation.growth_accumulator_head -= cell.config.GROWTH_THRESHOLD
+
+        while cell.physics_representation.growth_accumulator_tail >= cell.config.GROWTH_THRESHOLD:
+            cell.physics_representation.add_tail_segment()
+            cell.physics_representation.growth_accumulator_tail -= cell.config.GROWTH_THRESHOLD
+
         first_pivot_joint = cell.physics_representation.pivot_joints[0]
         first_pivot_joint.anchor_a = (
             cell.config.JOINT_DISTANCE / 2 + cell.physics_representation.growth_accumulator_head,
-            0
+            0,
         )
-
-        # Stretch the tail joint by adjusting the anchor on the last segment.
-        # This pushes the tail segment outwards.
         last_pivot_joint = cell.physics_representation.pivot_joints[-1]
         last_pivot_joint.anchor_b = (
             -cell.config.JOINT_DISTANCE / 2 - cell.physics_representation.growth_accumulator_tail,
             0,
         )
-
-        # If the head has grown enough, insert a new segment.
-        if cell.physics_representation.growth_accumulator_head >= cell.config.GROWTH_THRESHOLD:
-            cell.physics_representation.add_head_segment()
-            cell.physics_representation.growth_accumulator_head = 0.0
-
-        # If the tail has grown enough, insert a new segment.
-        if cell.physics_representation.growth_accumulator_tail >= cell.config.GROWTH_THRESHOLD:
-            cell.physics_representation.add_tail_segment()
-            cell.physics_representation.growth_accumulator_tail = 0.0

--- a/SyMBac/physics/segments.py
+++ b/SyMBac/physics/segments.py
@@ -106,10 +106,14 @@ class CellSegment:
     @radius.setter
     def radius(self, new_radius: float) -> None:
         if self.use_unsafe_radius_set:
-            self.shape.unsafe_set_radius(new_radius)  # More efficient but is it okay?
+            self.shape.unsafe_set_radius(new_radius)
         else:
             friction, filter = self.shape.friction, self.shape.filter
             self.space.remove(self.shape)
             self.shape = pymunk.Circle(self.body, new_radius)
             self.shape.friction, self.shape.filter = friction, filter
             self.space.add(self.shape)
+
+        self.body.moment = pymunk.moment_for_circle(self.body.mass, 0, new_radius)
+        if self.shape.space is not None:
+            self.shape.space.reindex_shape(self.shape)

--- a/SyMBac/physics/simulator.py
+++ b/SyMBac/physics/simulator.py
@@ -108,6 +108,7 @@ class Simulator:
         self.space: pymunk.Space = space
         self.space.threads = physics_config.THREADS
         self.space.iterations = physics_config.ITERATIONS
+        self._baseline_iterations = physics_config.ITERATIONS
         self.space.gravity = physics_config.GRAVITY
         self.space.damping = physics_config.DAMPING
         self.dt: float = physics_config.DT
@@ -322,7 +323,10 @@ class Simulator:
             hook(self)
 
         if self.adaptive_iterations:
-            self.space.iterations = max(10, int(self.space.iterations * 0.9))
+            self.space.iterations = max(
+                self._baseline_iterations,
+                int(self.space.iterations * 0.9),
+            )
             self.max_joint_impulse *= 0.9
 
         self.frame_count += 1

--- a/SyMBac/simulation.py
+++ b/SyMBac/simulation.py
@@ -24,6 +24,20 @@ def _atomic_pickle_dump(payload, output_path):
             os.remove(temp_path)
 
 
+def _handle_lysis(sim, lysis_p):
+    if lysis_p <= 0:
+        return
+
+    candidates = list(sim.colony.cells)
+    np.random.shuffle(candidates)
+    lysis_threshold = norm.ppf(lysis_p)
+    for cell in candidates:
+        if len(sim.colony.cells) <= 1:
+            break
+        if norm.rvs() <= lysis_threshold:
+            sim.colony.delete_cell(cell)
+
+
 class Simulation:
     
     """
@@ -207,6 +221,8 @@ class Simulation:
 
         if isinstance(substeps, bool) or not isinstance(substeps, int) or substeps <= 0:
             raise ValueError("substeps must be an integer greater than 0.")
+        if isinstance(lysis_p, bool) or not 0.0 <= lysis_p <= 1.0:
+            raise ValueError("lysis_p must be in [0.0, 1.0].")
         if cell_config_overrides is not None and not isinstance(cell_config_overrides, dict):
             raise TypeError("cell_config_overrides must be a dict when provided.")
         if physics_config_overrides is not None and not isinstance(physics_config_overrides, dict):
@@ -459,13 +475,7 @@ class Simulation:
                     sim.colony.delete_cell(cell)
 
         def handle_lysis(sim):
-            if self.lysis_p <= 0:
-                return
-            for cell in sim.colony.cells[:]:
-                if len(sim.colony.cells) <= 1:
-                    break
-                if norm.rvs() <= norm.ppf(self.lysis_p):
-                    sim.colony.delete_cell(cell)
+            _handle_lysis(sim, self.lysis_p)
 
         def apply_rigid_body_brownian_jitter(sim):
             if (

--- a/tests/test_colony_overlap.py
+++ b/tests/test_colony_overlap.py
@@ -1,3 +1,7 @@
+from types import SimpleNamespace
+
+import pytest
+
 from SyMBac.physics.colony import Colony
 
 
@@ -12,25 +16,29 @@ class _Segment:
 
 
 class _PhysicsRepresentation:
-    def __init__(self, shapes, tail_return=None, head_return=None):
+    def __init__(self, shapes, minimum_segments):
         self.segments = [_Segment(shape) for shape in shapes]
-        self._tail_return = tail_return
-        self._head_return = head_return
+        self.minimum_segments = minimum_segments
         self.tail_calls = 0
         self.head_calls = 0
 
     def remove_tail_segment(self):
         self.tail_calls += 1
-        return self._tail_return
+        if len(self.segments) <= self.minimum_segments:
+            return None
+        return self.segments.pop()
 
     def remove_head_segment(self):
         self.head_calls += 1
-        return self._head_return
+        if len(self.segments) <= self.minimum_segments:
+            return None
+        return self.segments.pop(0)
 
 
 class _Cell:
-    def __init__(self, physics_representation):
+    def __init__(self, physics_representation, minimum_segments):
         self.physics_representation = physics_representation
+        self.config = SimpleNamespace(MIN_LENGTH_AFTER_DIVISION=minimum_segments)
 
 
 class _Space:
@@ -41,13 +49,28 @@ class _Space:
         return [_QueryInfo(self._overlap_shape)]
 
 
-def test_handle_cell_overlaps_stops_cleanly_when_removal_returns_none():
+@pytest.mark.parametrize("mother_segments,daughter_segments", [(2, 3), (3, 2)])
+def test_handle_cell_overlaps_validates_both_cells_before_mutating(
+    mother_segments,
+    daughter_segments,
+):
+    minimum_segments = 2
     overlap_shape = object()
-    mother_pr = _PhysicsRepresentation(shapes=[overlap_shape], tail_return=None)
-    daughter_pr = _PhysicsRepresentation(shapes=[object()], head_return=None)
+    mother_pr = _PhysicsRepresentation(
+        shapes=[overlap_shape, *[object() for _ in range(mother_segments - 1)]],
+        minimum_segments=minimum_segments,
+    )
+    daughter_pr = _PhysicsRepresentation(
+        shapes=[object() for _ in range(daughter_segments)],
+        minimum_segments=minimum_segments,
+    )
+    mother = _Cell(mother_pr, minimum_segments)
+    daughter = _Cell(daughter_pr, minimum_segments)
 
     colony = Colony(space=_Space(overlap_shape), cells=[])
-    colony.handle_cell_overlaps({_Cell(daughter_pr): _Cell(mother_pr)})
+    colony.handle_cell_overlaps({daughter: mother})
 
-    assert mother_pr.tail_calls == 1
-    assert daughter_pr.head_calls == 1
+    assert mother_pr.tail_calls == 0
+    assert daughter_pr.head_calls == 0
+    assert len(mother_pr.segments) == mother_segments
+    assert len(daughter_pr.segments) == daughter_segments

--- a/tests/test_growth_physics_invariants.py
+++ b/tests/test_growth_physics_invariants.py
@@ -1,0 +1,129 @@
+import pymunk
+import pytest
+
+import SyMBac.simulation as simulation_module
+from SyMBac.physics.config import CellConfig, PhysicsConfig
+from SyMBac.physics.division_manager import DivisionManager
+from SyMBac.physics.growth_manager import GrowthManager
+from SyMBac.physics.segments import CellSegment
+from SyMBac.physics.simcell import SimCell
+from SyMBac.physics.simulator import Simulator
+
+
+def test_continuous_length_cell_can_grow_to_division_segment_count(monkeypatch):
+    config = CellConfig(
+        GRANULARITY=4,
+        SEGMENT_RADIUS=4.0,
+        GROWTH_RATE=1.0,
+        MIN_LENGTH_AFTER_DIVISION=3,
+        BASE_MAX_LENGTH=6.0,
+        SEED_CELL_SEGMENTS=2,
+        NOISE_STRENGTH=0.0,
+        SIMPLE_LENGTH=False,
+    )
+    space = pymunk.Space()
+    cell = SimCell(space=space, config=config, start_pos=(0, 0))
+    division_manager = DivisionManager(space=space, config=config)
+    monkeypatch.setattr(
+        "SyMBac.physics.growth_manager.np.random.uniform",
+        lambda *_args: 2.0,
+    )
+
+    assert cell.length >= cell.max_length
+    assert not division_manager.ready_to_divide(cell)
+
+    GrowthManager.grow(cell, dt=1.0)
+    GrowthManager.grow(cell, dt=1.0)
+
+    assert cell.physics_representation.num_segments == 6
+    assert division_manager.ready_to_divide(cell)
+
+
+def test_growth_preserves_overshoot_and_inserts_every_crossed_threshold(monkeypatch):
+    config = CellConfig(
+        GRANULARITY=4,
+        SEGMENT_RADIUS=4.0,
+        GROWTH_RATE=1.0,
+        MIN_LENGTH_AFTER_DIVISION=2,
+        BASE_MAX_LENGTH=100.0,
+        SEED_CELL_SEGMENTS=3,
+        NOISE_STRENGTH=0.0,
+    )
+    cell = SimCell(space=pymunk.Space(), config=config, start_pos=(0, 0))
+    monkeypatch.setattr(
+        "SyMBac.physics.growth_manager.np.random.uniform",
+        lambda *_args: 7.0,
+    )
+
+    GrowthManager.grow(cell, dt=1.0)
+
+    representation = cell.physics_representation
+    assert representation.num_segments == 9
+    assert representation.growth_accumulator_head == pytest.approx(0.5)
+    assert representation.growth_accumulator_tail == pytest.approx(0.5)
+    assert representation.pivot_joints[0].anchor_a.x == pytest.approx(1.0)
+    assert representation.pivot_joints[-1].anchor_b.x == pytest.approx(-1.0)
+
+
+def test_radius_update_refreshes_moment_and_spatial_index():
+    config = CellConfig(SEGMENT_RADIUS=2.0)
+    space = pymunk.Space()
+    segment = CellSegment(
+        config=config,
+        group_id=1,
+        position=pymunk.Vec2d(0, 0),
+        space=space,
+    )
+    space.add(segment.body, segment.shape)
+
+    assert space.point_query_nearest((3.0, 0.0), 0.0, pymunk.ShapeFilter()) is None
+
+    segment.radius = 4.0
+
+    expected_moment = pymunk.moment_for_circle(segment.body.mass, 0.0, 4.0)
+    assert segment.body.moment == pytest.approx(expected_moment)
+    hit = space.point_query_nearest((3.0, 0.0), 0.0, pymunk.ShapeFilter())
+    assert hit is not None
+    assert hit.shape is segment.shape
+
+
+def test_adaptive_iterations_decay_to_configured_baseline():
+    simulator = Simulator(
+        physics_config=PhysicsConfig(ITERATIONS=23),
+        initial_cell_config=CellConfig(GROWTH_RATE=0.0, NOISE_STRENGTH=0.0),
+        adaptive_iterations=True,
+    )
+    simulator.space.iterations = 24
+
+    simulator.step()
+
+    assert simulator.space.iterations == 23
+
+
+def test_lysis_randomizes_candidates_before_preserving_one_survivor(monkeypatch):
+    handle_lysis = getattr(simulation_module, "_handle_lysis", None)
+    assert callable(handle_lysis)
+
+    cells = [object(), object(), object()]
+
+    class _Colony:
+        def __init__(self):
+            self.cells = cells.copy()
+            self.deleted = []
+
+        def delete_cell(self, cell):
+            self.deleted.append(cell)
+            self.cells.remove(cell)
+
+    class _Simulator:
+        def __init__(self):
+            self.colony = _Colony()
+
+    simulator = _Simulator()
+    monkeypatch.setattr(simulation_module.np.random, "shuffle", lambda values: values.reverse())
+    monkeypatch.setattr(simulation_module.norm, "rvs", lambda: 0.0)
+
+    handle_lysis(simulator, lysis_p=1.0)
+
+    assert simulator.colony.deleted == [cells[2], cells[1]]
+    assert simulator.colony.cells == [cells[0]]

--- a/tests/test_physics_config_validation.py
+++ b/tests/test_physics_config_validation.py
@@ -29,3 +29,27 @@ def test_cell_config_defaults_are_constructible():
     assert cfg.ROTARY_LIMIT_JOINT is True
     assert cfg.MAX_BEND_ANGLE is not None
     assert cfg.STIFFNESS is not None
+
+
+@pytest.mark.parametrize(
+    "config_type,kwargs,error",
+    [
+        (CellConfig, {"GRANULARITY": 0}, "GRANULARITY"),
+        (CellConfig, {"GRANULARITY": 1.5}, "GRANULARITY"),
+        (CellConfig, {"SEPTUM_DURATION": 0.0}, "SEPTUM_DURATION"),
+        (CellConfig, {"SEPTUM_DURATION": float("inf")}, "SEPTUM_DURATION"),
+        (CellConfig, {"MIN_LENGTH_AFTER_DIVISION": 1}, "MIN_LENGTH_AFTER_DIVISION"),
+        (CellConfig, {"MIN_LENGTH_AFTER_DIVISION": 2.5}, "MIN_LENGTH_AFTER_DIVISION"),
+        (CellConfig, {"SEED_CELL_SEGMENTS": 1}, "SEED_CELL_SEGMENTS"),
+        (CellConfig, {"SEED_CELL_SEGMENTS": 2.5}, "SEED_CELL_SEGMENTS"),
+        (PhysicsConfig, {"DT": float("inf")}, "DT"),
+        (PhysicsConfig, {"ITERATIONS": 0}, "ITERATIONS"),
+        (PhysicsConfig, {"ITERATIONS": 1.5}, "ITERATIONS"),
+        (PhysicsConfig, {"DAMPING": -0.1}, "DAMPING"),
+        (PhysicsConfig, {"DAMPING": 1.1}, "DAMPING"),
+        (PhysicsConfig, {"DAMPING": float("nan")}, "DAMPING"),
+    ],
+)
+def test_configs_reject_invalid_core_values(config_type, kwargs, error):
+    with pytest.raises(ValueError, match=error):
+        config_type(**kwargs)

--- a/tests/test_substeps_validation.py
+++ b/tests/test_substeps_validation.py
@@ -44,6 +44,14 @@ def test_substeps_validation_accepts_positive_int(tmp_path):
     assert simulation.substeps == 3
 
 
+@pytest.mark.parametrize("bad_lysis_p", [-0.1, 1.1, float("nan")])
+def test_lysis_probability_must_be_in_unit_interval(tmp_path, bad_lysis_p):
+    kwargs = _simulation_kwargs(tmp_path)
+    kwargs["lysis_p"] = bad_lysis_p
+    with pytest.raises(ValueError, match="lysis_p"):
+        Simulation(**kwargs)
+
+
 @pytest.mark.parametrize(
     "field_name,bad_value",
     [


### PR DESCRIPTION
## What changed

- Let continuous-length cells keep growing until they contain enough segments for two viable daughters.
- Preserve growth-threshold overshoot and insert every segment implied by an update.
- Validate timestep, septum duration, granularity, solver iterations, damping, viable segment counts, and lysis probability before Pymunk receives them.
- Recompute rotational moment and reindex the Pymunk shape whenever segment radius changes.
- Preflight both cells before overlap trimming, restore adaptive iterations to the configured baseline, and randomize lysis candidate order.

## Why

Continuous length and segment-count division readiness could disagree permanently: growth stopped at the length threshold even when the cell did not contain enough segments to split. Separate state updates also discarded growth overshoot, left Pymunk inertia and spatial indexing stale after radius changes, could trim only one side of a mother-daughter pair, decayed solver iterations toward a hard-coded value, and favored cells late in colony list order during lysis.

## Validation

- `pixi run pytest -q tests/test_growth_physics_invariants.py tests/test_physics_config_validation.py tests/test_substeps_validation.py tests/test_colony_overlap.py` — 57 passed
- `pixi run pytest -q tests/test_simcell_core.py tests/test_division_manager_split.py tests/test_physics_config_validation.py tests/test_colony_overlap.py tests/test_substeps_validation.py tests/test_simulation_persistence.py tests/test_growth_physics_invariants.py` — 73 passed
- `pixi run pytest -q` — 86 passed, with the existing CPU FFT fallback warning