### PR TITLE
Fix renderer state, seeding, and repeated exports

### DIFF
--- a/SyMBac/renderer.py
+++ b/SyMBac/renderer.py
@@ -578,7 +578,7 @@ class Renderer:
 
     def generate_test_comparison(self, media_multiplier=75, cell_multiplier=1.7, device_multiplier=29, sigma=8.85,
                                  scene_no=-1, match_fourier=False, match_histogram=True, match_noise=False,
-                                 debug_plot=False, noise_var=0.001, defocus=3.0, halo_top_intensity = 1, halo_bottom_intensity = 1, halo_start = 0, halo_end = 1, random_real_image = None, cell_texture_strength=0.0, cell_texture_scale=70.0, edge_floor_opl=0.0):
+                                 debug_plot=False, noise_var=0.001, defocus=3.0, halo_top_intensity = 1, halo_bottom_intensity = 1, halo_start = 0, halo_end = 1, random_real_image = None, cell_texture_strength=0.0, cell_texture_scale=70.0, edge_floor_opl=0.0, rng=None):
         """
         Takes all the parameters we've defined and calculated, and uses them to finally generate a synthetic image.
 
@@ -631,6 +631,8 @@ class Renderer:
         edge_floor_opl : float
             Minimum non-zero OPL floor applied to cell pixels before
             multiplier scaling and convolution.
+        rng : numpy.random.Generator, optional
+            Random generator used for camera or ad-hoc noise.
 
 
 
@@ -642,6 +644,7 @@ class Renderer:
             The final image's accompanying masks
         """
 
+        rng = np.random.default_rng() if rng is None else rng
         base_scene = self.simulation.OPL_scenes[scene_no]
 
         if cell_texture_strength > 0:
@@ -701,20 +704,21 @@ class Renderer:
         expanded_scene[expanded_scene.shape[0] - len(halo_array):,:] *= halo_array
         expanded_scene_no_cells[expanded_scene_no_cells.shape[0] - len(halo_array):,:] *= halo_array
 
-        if self.PSF.mode == "phase contrast":
-            R, W, radius, scale, NA, n, _, λ = self.PSF.R, self.PSF.W, self.PSF.radius, self.PSF.scale, self.PSF.NA, self.PSF.n, self.PSF.apo_sigma, self.PSF.wavelength
+        render_psf = self.PSF
+        if render_psf.mode == "phase contrast":
+            R, W, radius, scale, NA, n, _, λ = render_psf.R, render_psf.W, render_psf.radius, render_psf.scale, render_psf.NA, render_psf.n, render_psf.apo_sigma, render_psf.wavelength
         else:
-            radius, scale, NA, n, _, λ = self.PSF.radius, self.PSF.scale, self.PSF.NA, self.PSF.n, self.PSF.apo_sigma, self.PSF.wavelength
+            radius, scale, NA, n, _, λ = render_psf.radius, render_psf.scale, render_psf.NA, render_psf.n, render_psf.apo_sigma, render_psf.wavelength
         real_media_mean, real_cell_mean, real_device_mean, real_means, real_media_var, real_cell_var, real_device_var, real_vars = self.image_params
         mean_error, media_error, cell_error, device_error, mean_var_error, media_var_error, cell_var_error, device_var_error = self.error_params
 
-        if self.PSF.mode == "phase contrast":
-            self.PSF = PSF_generator(radius=self.PSF.radius, wavelength=self.PSF.wavelength, NA=self.PSF.NA,
-                                     n=self.PSF.n, resize_amount=self.simulation.resize_amount,
+        if render_psf.mode == "phase contrast":
+            render_psf = PSF_generator(radius=render_psf.radius, wavelength=render_psf.wavelength, NA=render_psf.NA,
+                                     n=render_psf.n, resize_amount=self.simulation.resize_amount,
                                      pix_mic_conv=self.simulation.pix_mic_conv, apo_sigma=sigma, mode="phase contrast",
-                                     condenser=self.PSF.condenser)
-            self.PSF.calculate_PSF()
-        if self.PSF.mode.lower() == "3d fluo":  # Full 3D PSF model
+                                     condenser=render_psf.condenser)
+            render_psf.calculate_PSF()
+        if render_psf.mode.lower() == "3d fluo":  # Full 3D PSF model
             def generate_deviation_from_CL(centreline, thickness):
                 return np.arange(thickness) + centreline - int(np.ceil(thickness / 2))
 
@@ -740,7 +744,7 @@ class Renderer:
             convolved = rescale(convolved, 1 / self.simulation.resize_amount, anti_aliasing=False)
             convolved = rescale_intensity(convolved.astype(np.float32), out_range=(0, 1))
         else:
-            kernel = self.PSF.kernel
+            kernel = render_psf.kernel
             if defocus > 0:
                 kernel = gaussian_filter(kernel, defocus, mode="reflect")
             convolved = convolve_rescale(expanded_scene, kernel, 1 / self.simulation.resize_amount, rescale_int=True)
@@ -772,15 +776,14 @@ class Renderer:
 
         if self.camera:  # Camera noise simulation
             baseline, sensitivity, dark_noise = self.camera.baseline, self.camera.sensitivity, self.camera.dark_noise
-            rng = np.random.default_rng(2)
             matched = matched / (matched.max() / self.real_image.max()) / sensitivity
             if match_fourier:
                 matched += abs(matched.min()) # Preserve mean > 0 for rng.poisson(matched)
             matched = rng.poisson(matched)
             noisy_img = matched + rng.normal(loc=baseline, scale=dark_noise, size=matched.shape)
         else:  # Ad hoc noise mathcing
-            noisy_img = random_noise(rescale_intensity(matched), mode="poisson")
-            noisy_img = random_noise(rescale_intensity(noisy_img), mode="gaussian", mean=0, var=noise_var, clip=False)
+            noisy_img = random_noise(rescale_intensity(matched), mode="poisson", rng=rng)
+            noisy_img = random_noise(rescale_intensity(noisy_img), mode="gaussian", mean=0, var=noise_var, clip=False, rng=rng)
 
         if match_noise:
             noisy_img = match_histograms(noisy_img, real_resize)
@@ -830,7 +833,7 @@ class Renderer:
                                    just_device[np.where(just_device)].var()])
         mean_error.append(perc_diff(np.mean(noisy_img), np.mean(real_resize)))
         mean_var_error.append(perc_diff(np.var(noisy_img), np.var(real_resize)))
-        if "fluo" in self.PSF.mode.lower():
+        if "fluo" in render_psf.mode.lower():
             pass
         else:
             media_error.append(perc_diff(simulated_means[0], real_media_mean))
@@ -1125,22 +1128,22 @@ class Renderer:
             The save directory of the training data
         in_series : bool
             Whether the images should be randomly sampled, or rendered in the order that the simulation was run in.
-        seed : float
-            Optional arg, if specified then the numpy random seed will be set for the rendering, allows reproducible rendering results.
+        seed : int, optional
+            Seed for reproducible parameter sampling, real-image selection,
+            and image noise. The default ``False`` leaves rendering unseeded.
 
         """
+
+        seed_value = None if seed is False else seed
+        parameter_rng = np.random.default_rng(seed_value)
+        selection_rng = random.Random(seed_value)
 
         if render_sample_parameters:
              warnings.warn(f"""
                            render_sample_parameters has been passed. Ignoring all function args
                            """, UserWarning)
-        def generate_samples(z, media_multiplier, cell_multiplier, device_multiplier, sigma, scene_no, match_histogram, match_noise, match_fourier):
-            
-            if self.additional_real_images:
-                random_real_image = random.choice(self.additional_real_images)
-            else:
-                random_real_image = None
-            
+        def generate_samples(z, media_multiplier, cell_multiplier, device_multiplier, sigma, scene_no, match_histogram, match_noise, match_fourier, random_real_image, sample_seed):
+            sample_rng = np.random.default_rng(sample_seed)
             syn_image, mask, superres_mask = self.generate_test_comparison(
                 media_multiplier=media_multiplier,
                 cell_multiplier=cell_multiplier,
@@ -1161,6 +1164,7 @@ class Renderer:
                 cell_texture_strength=self.params.kwargs["cell_texture_strength"],
                 cell_texture_scale=self.params.kwargs["cell_texture_scale"],
                 edge_floor_opl=self.params.kwargs.get("edge_floor_opl", 0.0),
+                rng=sample_rng,
             )
 
             syn_image = Image.fromarray(skimage.img_as_uint(rescale_intensity(syn_image)))
@@ -1173,7 +1177,7 @@ class Renderer:
 
                 superres_mask = np.zeros(superres_mask.shape)
                 superres_mask = Image.fromarray(superres_mask.astype(mask_dtype))
-                superres_mask.save("{}/superres_masks/{}synth_{}.png".format(save_dir, str(z).zfill(5)))
+                superres_mask.save("{}/superres_masks/{}synth_{}.png".format(save_dir, prefix, str(z).zfill(5)))
             else:
                 mask, superres_mask = _relabel_instance_masks(
                     mask,
@@ -1185,12 +1189,6 @@ class Renderer:
 
                 superres_mask = Image.fromarray(superres_mask)
                 superres_mask.save("{}/superres_masks/{}synth_{}.png".format(save_dir, prefix, str(z).zfill(5)))
-
-
-
-        if seed:
-            np.random.seed(seed)
-
         try:
             os.mkdir(save_dir)
         except:
@@ -1216,31 +1214,31 @@ class Renderer:
                 series_len = (self.simulation.sim_length) - burn_in
                 n_series_to_sim = int(np.ceil(n_samples/series_len))
 
-                media_multipliers = np.repeat([np.random.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["media_multiplier"] for _ in range(n_series_to_sim)], series_len)
-                cell_multipliers = np.repeat([np.random.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["cell_multiplier"] for _ in range(n_series_to_sim)], series_len)
-                device_multipliers = np.repeat([np.random.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["device_multiplier"] for _ in range(n_series_to_sim)], series_len)
-                sigmas = np.repeat([np.random.uniform(1 - sample_amount, 1 + sample_amount)* self.params.kwargs["sigma"] for _ in range(n_series_to_sim)], series_len)
+                media_multipliers = np.repeat([parameter_rng.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["media_multiplier"] for _ in range(n_series_to_sim)], series_len)
+                cell_multipliers = np.repeat([parameter_rng.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["cell_multiplier"] for _ in range(n_series_to_sim)], series_len)
+                device_multipliers = np.repeat([parameter_rng.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["device_multiplier"] for _ in range(n_series_to_sim)], series_len)
+                sigmas = np.repeat([parameter_rng.uniform(1 - sample_amount, 1 + sample_amount)* self.params.kwargs["sigma"] for _ in range(n_series_to_sim)], series_len)
                 scene_nos =  np.arange(burn_in, self.simulation.sim_length).tolist() * n_series_to_sim
 
             else:
-                media_multipliers = [np.random.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["media_multiplier"] for _ in range(n_samples)]
-                cell_multipliers = [np.random.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["cell_multiplier"] for _ in range(n_samples)]
-                device_multipliers = [np.random.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["device_multiplier"] for _ in range(n_samples)]
-                sigmas = [np.random.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["sigma"] for _ in range(n_samples)]
-                scene_nos = np.random.randint(low = burn_in, high = self.simulation.sim_length - 2, size = n_samples)
+                media_multipliers = [parameter_rng.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["media_multiplier"] for _ in range(n_samples)]
+                cell_multipliers = [parameter_rng.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["cell_multiplier"] for _ in range(n_samples)]
+                device_multipliers = [parameter_rng.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["device_multiplier"] for _ in range(n_samples)]
+                sigmas = [parameter_rng.uniform(1 - sample_amount, 1 + sample_amount) * self.params.kwargs["sigma"] for _ in range(n_samples)]
+                scene_nos = parameter_rng.integers(low = burn_in, high = self.simulation.sim_length - 2, size = n_samples)
 
             if randomise_hist_match:
-                hist_match_bools = np.random.choice([True, False], size = n_samples)
+                hist_match_bools = parameter_rng.choice([True, False], size = n_samples)
             else:
                 hist_match_bools = [self.params.kwargs["match_histogram"]] * n_samples
 
             if randomise_noise_match:
-                noise_match_bools = np.random.choice([True, False], size = n_samples)
+                noise_match_bools = parameter_rng.choice([True, False], size = n_samples)
             else:
                 noise_match_bools = [self.params.kwargs["match_noise"]] * n_samples 
 
             if randomise_fourier_match:
-                fourier_match_bools = np.random.choice([True, False], size = n_samples)
+                fourier_match_bools = parameter_rng.choice([True, False], size = n_samples)
             else:
                 fourier_match_bools = [self.params.kwargs["match_fourier"]] * n_samples
 
@@ -1259,17 +1257,28 @@ class Renderer:
 
         if dry_run:
             return render_sample_parameters
-        
 
-
-
+        sample_count = render_sample_parameters["n_samples"]
+        sample_seeds = parameter_rng.integers(
+            0,
+            np.iinfo(np.uint64).max,
+            size=sample_count,
+            dtype=np.uint64,
+        )
+        if self.additional_real_images:
+            random_real_images = [
+                selection_rng.choice(self.additional_real_images)
+                for _ in range(sample_count)
+            ]
+        else:
+            random_real_images = [None] * sample_count
         Parallel(
             n_jobs=n_jobs, backend="threading"
             )(
                 delayed(generate_samples)(
-                    z, media_multiplier, cell_multiplier, device_multiplier, sigma, scene_no, match_histogram, match_noise, match_fourier) for z, media_multiplier, cell_multiplier, device_multiplier, sigma, scene_no, match_histogram, match_noise, match_fourier in tqdm(
+                    z, media_multiplier, cell_multiplier, device_multiplier, sigma, scene_no, match_histogram, match_noise, match_fourier, random_real_image, sample_seed) for z, media_multiplier, cell_multiplier, device_multiplier, sigma, scene_no, match_histogram, match_noise, match_fourier, random_real_image, sample_seed in tqdm(
                                 zip(
-                                    range(render_sample_parameters["n_samples"]), render_sample_parameters["media_multipliers"], render_sample_parameters["cell_multipliers"], render_sample_parameters["device_multipliers"], render_sample_parameters["sigmas"], render_sample_parameters["scene_nos"], render_sample_parameters["hist_match_bools"], render_sample_parameters["noise_match_bools"], render_sample_parameters["fourier_match_bools"])
+                                    range(current_file_num, current_file_num + sample_count), render_sample_parameters["media_multipliers"], render_sample_parameters["cell_multipliers"], render_sample_parameters["device_multipliers"], render_sample_parameters["sigmas"], render_sample_parameters["scene_nos"], render_sample_parameters["hist_match_bools"], render_sample_parameters["noise_match_bools"], render_sample_parameters["fourier_match_bools"], random_real_images, sample_seeds)
                                 , desc="Rendering synthetic images"))
 
     def generate_timeseries_training_data(
@@ -1328,10 +1337,8 @@ class Renderer:
         image_ext = "png" if image_format == "png" else "tiff"
         mask_dtype = np.dtype(mask_dtype)
 
-        if seed is not None:
-            random.seed(seed)
-            np.random.seed(seed)
         rng = np.random.default_rng(seed)
+        selection_rng = random.Random(seed)
 
         os.makedirs(save_dir, exist_ok=True)
         scene_nos = np.arange(burn_in, burn_in + frames_per_series, dtype=int)
@@ -1387,9 +1394,15 @@ class Renderer:
             os.makedirs(masks_dir, exist_ok=True)
 
             params = _series_parameters()
-            series_real_image = random.choice(self.additional_real_images) if self.additional_real_images else None
+            series_real_image = selection_rng.choice(self.additional_real_images) if self.additional_real_images else None
+            frame_seeds = rng.integers(
+                0,
+                np.iinfo(np.uint64).max,
+                size=len(scene_nos),
+                dtype=np.uint64,
+            )
 
-            def _render_one(frame_idx, scene_no):
+            def _render_one(frame_idx, scene_no, frame_seed):
                 syn_image, mask, _ = self.generate_test_comparison(
                     media_multiplier=params["media_multiplier"],
                     cell_multiplier=params["cell_multiplier"],
@@ -1410,6 +1423,7 @@ class Renderer:
                     cell_texture_strength=params["cell_texture_strength"],
                     cell_texture_scale=params["cell_texture_scale"],
                     edge_floor_opl=params["edge_floor_opl"],
+                    rng=np.random.default_rng(frame_seed),
                 )
                 image_path = os.path.join(images_dir, f"frame_{frame_idx:05d}.{image_ext}")
                 mask_path = os.path.join(masks_dir, f"frame_{frame_idx:05d}.{image_ext}")
@@ -1429,10 +1443,10 @@ class Renderer:
                 }
 
             if n_jobs == 1:
-                frames = [_render_one(frame_idx, scene_no) for frame_idx, scene_no in enumerate(scene_nos)]
+                frames = [_render_one(frame_idx, scene_no, frame_seeds[frame_idx]) for frame_idx, scene_no in enumerate(scene_nos)]
             else:
                 frames = Parallel(n_jobs=n_jobs, backend="threading")(
-                    delayed(_render_one)(frame_idx, scene_no)
+                    delayed(_render_one)(frame_idx, scene_no, frame_seeds[frame_idx])
                     for frame_idx, scene_no in enumerate(scene_nos)
                 )
                 frames = sorted(frames, key=lambda item: item["frame_idx"])

--- a/tests/test_renderer_mask_export.py
+++ b/tests/test_renderer_mask_export.py
@@ -1,9 +1,12 @@
+import random
+import threading
 from types import MethodType, SimpleNamespace
 
 import numpy as np
 import pytest
 from PIL import Image
 
+import SyMBac.renderer as renderer_module
 from SyMBac.renderer import Renderer
 
 
@@ -12,6 +15,13 @@ def _renderer_returning(mask, superres_mask):
     renderer.additional_real_images = []
     renderer.params = SimpleNamespace(
         kwargs={
+            "media_multiplier": 10.0,
+            "cell_multiplier": 2.0,
+            "device_multiplier": 5.0,
+            "sigma": 1.5,
+            "match_histogram": False,
+            "match_noise": False,
+            "match_fourier": False,
             "noise_var": 0.0,
             "defocus": 0.0,
             "halo_top_intensity": 0.0,
@@ -31,6 +41,70 @@ def _renderer_returning(mask, superres_mask):
         generate_test_comparison,
         renderer,
     )
+    return renderer
+
+
+def _comparison_renderer(mode="simple fluo", camera=None):
+    renderer = Renderer.__new__(Renderer)
+    scene = np.arange(1, 65, dtype=float).reshape(8, 8)
+    mask = np.zeros((8, 8), dtype=np.uint16)
+    mask[2:6, 2:6] = 1
+
+    renderer.simulation = SimpleNamespace(
+        OPL_scenes=[scene],
+        masks=[mask],
+        resize_amount=1,
+        pix_mic_conv=1.0,
+    )
+    renderer.real_image = np.arange(1, 17, dtype=float).reshape(4, 4)
+    renderer.PSF = SimpleNamespace(
+        mode=mode,
+        R=1.0,
+        W=1.0,
+        radius=1,
+        scale=1.0,
+        NA=0.8,
+        n=1.33,
+        apo_sigma=1.0,
+        wavelength=0.6,
+        condenser="Ph1",
+        kernel=np.array([[1.0]]),
+    )
+    renderer.camera = camera
+    renderer.additional_real_images = []
+    renderer.x_border_expansion_coefficient = 1
+    renderer.y_border_expansion_coefficient = 1
+    renderer.image_params = (0.5, 0.5, 0.5, None, 0.1, 0.1, 0.1, None)
+    renderer.error_params = tuple([] for _ in range(8))
+    renderer.params = SimpleNamespace(
+        kwargs={
+            "noise_var": 0.01,
+            "defocus": 0.0,
+            "halo_top_intensity": 1.0,
+            "halo_bottom_intensity": 1.0,
+            "halo_start": 0.0,
+            "halo_end": 1.0,
+            "cell_texture_strength": 0.0,
+            "cell_texture_scale": 1.0,
+        }
+    )
+
+    def generate_PC_OPL(
+        self,
+        scene,
+        mask,
+        media_multiplier,
+        cell_multiplier,
+        device_multiplier,
+        **_kwargs,
+    ):
+        expanded_scene = np.array(scene, copy=True)
+        expanded_scene[0, 0] = media_multiplier
+        expanded_scene_no_cells = np.zeros_like(expanded_scene)
+        expanded_scene_no_cells[2:6, 2:6] = device_multiplier
+        return expanded_scene, expanded_scene_no_cells, np.array(mask, copy=True)
+
+    renderer.generate_PC_OPL = MethodType(generate_PC_OPL, renderer)
     return renderer
 
 
@@ -110,3 +184,225 @@ def test_generate_training_data_rejects_more_instances_than_dtype_can_store(tmp_
                 mask_dtype=np.uint8,
                 render_sample_parameters=_render_parameters(),
             )
+
+
+def test_parallel_training_uses_each_samples_psf_kernel(tmp_path, monkeypatch):
+    renderer = _comparison_renderer(mode="phase contrast")
+    original_psf = renderer.PSF
+    psf_ready = threading.Barrier(2, timeout=5)
+    convolutions = {}
+
+    class SynchronizedPSF:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            self.R = 1.0
+            self.W = 1.0
+            self.scale = 1.0
+
+        def calculate_PSF(self):
+            self.kernel = np.array([[self.apo_sigma]])
+            psf_ready.wait()
+
+    def record_convolution(image, kernel, _rescale_factor, rescale_int):
+        convolutions[float(image[0, 0])] = float(kernel[0, 0])
+        return np.arange(image.size, dtype=float).reshape(image.shape)
+
+    monkeypatch.setattr(renderer_module, "PSF_generator", SynchronizedPSF)
+    monkeypatch.setattr(renderer_module, "convolve_rescale", record_convolution)
+
+    parameters = {
+        "n_samples": 2,
+        "media_multipliers": [10.0, 20.0],
+        "cell_multipliers": [1.0, 1.0],
+        "device_multipliers": [2.0, 2.0],
+        "sigmas": [1.0, 2.0],
+        "scene_nos": [0, 0],
+        "hist_match_bools": [False, False],
+        "noise_match_bools": [False, False],
+        "fourier_match_bools": [False, False],
+    }
+
+    with pytest.warns(UserWarning, match="render_sample_parameters"):
+        renderer.generate_training_data(
+            sample_amount=0,
+            randomise_hist_match=False,
+            randomise_noise_match=False,
+            burn_in=0,
+            n_samples=2,
+            save_dir=str(tmp_path),
+            n_jobs=2,
+            render_sample_parameters=parameters,
+        )
+
+    assert convolutions == {10.0: 1.0, 20.0: 2.0}
+    assert renderer.PSF is original_psf
+
+
+@pytest.mark.parametrize(
+    "camera",
+    [None, SimpleNamespace(baseline=1.0, sensitivity=1.0, dark_noise=0.5)],
+    ids=["skimage-noise", "camera-noise"],
+)
+def test_generate_test_comparison_noise_respects_rng(camera):
+    renderer = _comparison_renderer(camera=camera)
+    render_kwargs = {
+        "media_multiplier": 10.0,
+        "cell_multiplier": 1.0,
+        "device_multiplier": 2.0,
+        "sigma": 1.0,
+        "scene_no": 0,
+        "match_fourier": False,
+        "match_histogram": False,
+        "match_noise": False,
+        "noise_var": 0.01,
+        "defocus": 0.0,
+        "halo_top_intensity": 1.0,
+        "halo_bottom_intensity": 1.0,
+        "halo_start": 0.0,
+        "halo_end": 1.0,
+    }
+
+    first = renderer.generate_test_comparison(
+        **render_kwargs,
+        rng=np.random.default_rng(0),
+    )[0]
+    repeated = renderer.generate_test_comparison(
+        **render_kwargs,
+        rng=np.random.default_rng(0),
+    )[0]
+    changed = renderer.generate_test_comparison(
+        **render_kwargs,
+        rng=np.random.default_rng(1),
+    )[0]
+
+    assert np.array_equal(first, repeated)
+    assert not np.array_equal(first, changed)
+
+
+def test_seed_reproduces_parameters_real_image_selection_and_noise(tmp_path):
+    captures = []
+    mask = np.array([[0, 1], [1, 0]], dtype=np.uint8)
+    renderer = _renderer_returning(mask, mask)
+    renderer.simulation = SimpleNamespace(sim_length=8)
+    renderer.additional_real_images = [
+        np.full((2, 2), 1.0),
+        np.full((2, 2), 2.0),
+    ]
+
+    def generate_test_comparison(self, **kwargs):
+        rng = kwargs["rng"]
+        captures.append(
+            (
+                kwargs["media_multiplier"],
+                float(kwargs["random_real_image"][0, 0]),
+                rng.random(4),
+            )
+        )
+        return rng.random((2, 2)), mask.copy(), mask.copy()
+
+    renderer.generate_test_comparison = MethodType(generate_test_comparison, renderer)
+
+    def render(seed, global_seed, output_dir):
+        random.seed(global_seed)
+        np.random.seed(global_seed)
+        captures.clear()
+        renderer.generate_training_data(
+            sample_amount=0.2,
+            randomise_hist_match=True,
+            randomise_noise_match=True,
+            burn_in=0,
+            n_samples=6,
+            save_dir=str(output_dir),
+            seed=seed,
+            n_jobs=1,
+        )
+        return [
+            (media_multiplier, real_image, noise.copy())
+            for media_multiplier, real_image, noise in captures
+        ]
+
+    python_random_state = random.getstate()
+    numpy_random_state = np.random.get_state()
+    try:
+        first = render(0, 1, tmp_path / "first")
+        repeated = render(0, 5, tmp_path / "repeated")
+        changed = render(1, 1, tmp_path / "changed")
+    finally:
+        random.setstate(python_random_state)
+        np.random.set_state(numpy_random_state)
+
+    for first_sample, repeated_sample in zip(first, repeated):
+        assert first_sample[:2] == repeated_sample[:2]
+        assert np.array_equal(first_sample[2], repeated_sample[2])
+    assert any(
+        first_sample[:2] != changed_sample[:2]
+        or not np.array_equal(first_sample[2], changed_sample[2])
+        for first_sample, changed_sample in zip(first, changed)
+    )
+
+
+def test_timeseries_seed_reproduces_parallel_frame_noise(tmp_path):
+    mask = np.array([[0, 1], [1, 0]], dtype=np.uint16)
+    renderer = _renderer_returning(mask, mask)
+    renderer.simulation = SimpleNamespace(sim_length=4)
+
+    def generate_test_comparison(self, **kwargs):
+        return kwargs["rng"].random((2, 2)), mask.copy(), mask.copy()
+
+    renderer.generate_test_comparison = MethodType(generate_test_comparison, renderer)
+
+    for output_dir in (tmp_path / "first", tmp_path / "repeated"):
+        renderer.generate_timeseries_training_data(
+            save_dir=str(output_dir),
+            burn_in=0,
+            sample_amount=0.0,
+            n_series=1,
+            frames_per_series=2,
+            export_geff=False,
+            seed=0,
+            n_jobs=2,
+            image_format="png",
+        )
+
+    for frame_number in range(2):
+        relative_path = f"series_000/images/frame_{frame_number:05d}.png"
+        first = np.asarray(Image.open(tmp_path / "first" / relative_path))
+        repeated = np.asarray(Image.open(tmp_path / "repeated" / relative_path))
+        assert np.array_equal(first, repeated)
+
+
+def test_repeated_export_advances_number_and_prefixes_zero_cell_masks(tmp_path):
+    mask = np.array([[0, 1], [1, 0]], dtype=np.uint8)
+    renderer = _renderer_returning(mask, mask)
+
+    with pytest.warns(UserWarning, match="render_sample_parameters"):
+        renderer.generate_training_data(
+            sample_amount=0,
+            randomise_hist_match=False,
+            randomise_noise_match=False,
+            burn_in=0,
+            n_samples=1,
+            save_dir=str(tmp_path),
+            n_jobs=1,
+            prefix="batch_",
+            render_sample_parameters=_render_parameters(),
+        )
+
+    zero_cell_parameters = _render_parameters()
+    zero_cell_parameters["cell_multipliers"] = [0.0]
+    with pytest.warns(UserWarning, match="render_sample_parameters"):
+        renderer.generate_training_data(
+            sample_amount=0,
+            randomise_hist_match=False,
+            randomise_noise_match=False,
+            burn_in=0,
+            n_samples=1,
+            save_dir=str(tmp_path),
+            n_jobs=1,
+            prefix="batch_",
+            render_sample_parameters=zero_cell_parameters,
+        )
+
+    expected_names = ["batch_synth_00000.png", "batch_synth_00001.png"]
+    for subdirectory in ("convolutions", "masks", "superres_masks"):
+        assert sorted(path.name for path in (tmp_path / subdirectory).iterdir()) == expected_names


### PR DESCRIPTION
## What changed

- Build each phase-contrast PSF in the render job that uses it, so threaded jobs no longer replace or read a shared `renderer.PSF`.
- Use local seeded NumPy generators and a local Python random source for parameter sampling, reference-image selection, camera noise, and skimage noise. `seed=0` is now treated as a real seed, and parallel time-series frames receive deterministic per-frame generators.
- Start repeated exports at the computed current file count instead of writing from zero again.
- Apply the requested prefix to zero-cell super-resolution masks as well as the normal export paths.
- Add focused regressions for the synchronized threaded race, seeded NumPy/Python/skimage and camera behavior, parallel time-series noise, and repeated export numbering/prefixes.

## Why

Threaded phase-contrast renders assigned newly generated PSFs to shared renderer state. Once two jobs overlapped, either job could convolve with the other job's kernel. The existing seed only affected global NumPy sampling when it was truthy; Python selection and skimage noise were independent, `seed=0` was ignored, and camera noise restarted from seed 2 on every render. Repeated exports computed the existing file count but still generated names from zero, while the zero-cell super-resolution path omitted the prefix argument entirely.

## Validation

- `pixi run pytest -q tests/test_renderer_mask_export.py tests/test_geff_export.py` — 11 passed
- `pixi run pytest -q` — 69 passed; one existing warning reports the expected CPU FFT convolution fallback when no GPU backend is installed