### PR TITLE
Fix mask labels and lineage GEFF exports

### DIFF
--- a/SyMBac/lineage.py
+++ b/SyMBac/lineage.py
@@ -243,7 +243,6 @@ class Lineage:
                     x_px = np.nan
                     y_px = np.nan
 
-            lineage_root = self._resolve_lineage_root(mask_label)
             generation = getattr(cell, "generation", 0)
             generation = int(generation) if not self._is_missing(generation) else 0
 
@@ -254,7 +253,6 @@ class Lineage:
                 y=float(y_px * spatial_scale) if np.isfinite(y_px) else np.nan,
                 seg_id=int(mask_label),
                 tracklet_id=int(mask_label),
-                lineage_id=int(lineage_root) if not self._is_missing(lineage_root) else -1,
                 length=float(getattr(cell, "length", np.nan) * spatial_scale),
                 width=float(getattr(cell, "width", np.nan) * spatial_scale),
                 angle=float(getattr(cell, "angle", np.nan)),
@@ -265,6 +263,11 @@ class Lineage:
         for source, target in self.temporal_lineage_graph.edges:
             if source in node_lookup and target in node_lookup:
                 geff_graph.add_edge(node_lookup[source], node_lookup[target])
+
+        for component in nx.weakly_connected_components(geff_graph):
+            lineage_id = min(component)
+            for node_id in component:
+                geff_graph.nodes[node_id]["lineage_id"] = lineage_id
 
         metadata = geff.GeffMetadata(
             directed=True,

--- a/SyMBac/lineage.py
+++ b/SyMBac/lineage.py
@@ -81,14 +81,28 @@ class Lineage:
             t = getattr(cell, "t", None)
             if self._is_missing(mask_label) or self._is_missing(t):
                 continue
-            self.temporal_lineage_graph.add_node((mask_label, t), cell=cell)
+            node = (mask_label, t)
+            if node in self.temporal_lineage_graph:
+                raise ValueError(
+                    f"Duplicate detection for mask_label={mask_label} at time={t}."
+                )
+            self.temporal_lineage_graph.add_node(node, cell=cell)
 
         for node in list(self.temporal_lineage_graph.nodes):
             exp_node = (node[0], node[1]-1)
             if exp_node in self.temporal_lineage_graph.nodes:
                 self.temporal_lineage_graph.add_edge(exp_node, node)
 
+        first_time_by_label = {}
+        for mask_label, t in self.temporal_lineage_graph.nodes:
+            first_time_by_label[mask_label] = min(
+                t,
+                first_time_by_label.get(mask_label, t),
+            )
+
         for node in list(self.temporal_lineage_graph.nodes):
+            if node[1] != first_time_by_label[node[0]]:
+                continue
             cell = self.temporal_lineage_graph.nodes[node]["cell"]
             mother_mask_label = getattr(cell, "mother_mask_label", None)
 
@@ -241,8 +255,8 @@ class Lineage:
                 seg_id=int(mask_label),
                 tracklet_id=int(mask_label),
                 lineage_id=int(lineage_root) if not self._is_missing(lineage_root) else -1,
-                length=float(getattr(cell, "length", np.nan)),
-                width=float(getattr(cell, "width", np.nan)),
+                length=float(getattr(cell, "length", np.nan) * spatial_scale),
+                width=float(getattr(cell, "width", np.nan) * spatial_scale),
                 angle=float(getattr(cell, "angle", np.nan)),
                 generation=generation,
             )
@@ -252,26 +266,32 @@ class Lineage:
             if source in node_lookup and target in node_lookup:
                 geff_graph.add_edge(node_lookup[source], node_lookup[target])
 
-        # geff backend kwargs vary across versions; newer docs include
-        # track-node mapping kwargs that older versions reject.
-        try:
-            geff.write(
-                geff_graph,
-                store,
-                axis_names=["t", "y", "x"],
-                axis_types=["time", "space", "space"],
-                zarr_format=zarr_format,
-                overwrite=overwrite,
-                track_node_props={"tracklet": "tracklet_id", "lineage": "lineage_id"},
-            )
-        except TypeError as exc:
-            if "track_node_props" not in str(exc):
-                raise
-            geff.write(
-                geff_graph,
-                store,
-                axis_names=["t", "y", "x"],
-                axis_types=["time", "space", "space"],
-                zarr_format=zarr_format,
-                overwrite=overwrite,
-            )
+        metadata = geff.GeffMetadata(
+            directed=True,
+            node_props_metadata={
+                name: {
+                    "identifier": name,
+                    "dtype": dtype,
+                    "unit": unit,
+                }
+                for name, dtype, unit in (
+                    ("t", "int64", "frame"),
+                    ("y", "float64", "micrometer"),
+                    ("x", "float64", "micrometer"),
+                    ("length", "float64", "micrometer"),
+                    ("width", "float64", "micrometer"),
+                )
+            },
+            edge_props_metadata={},
+            track_node_props={"tracklet": "tracklet_id", "lineage": "lineage_id"},
+        )
+        geff.write(
+            geff_graph,
+            store,
+            metadata=metadata,
+            axis_names=["t", "y", "x"],
+            axis_units=["frame", "micrometer", "micrometer"],
+            axis_types=["time", "space", "space"],
+            zarr_format=zarr_format,
+            overwrite=overwrite,
+        )

--- a/SyMBac/lineage.py
+++ b/SyMBac/lineage.py
@@ -104,6 +104,8 @@ class Lineage:
             if node[1] != first_time_by_label[node[0]]:
                 continue
             cell = self.temporal_lineage_graph.nodes[node]["cell"]
+            if hasattr(cell, "just_divided") and not bool(cell.just_divided):
+                continue
             mother_mask_label = getattr(cell, "mother_mask_label", None)
 
             if self._is_missing(mother_mask_label):
@@ -186,12 +188,12 @@ class Lineage:
         if resize_amount is None:
             resize_amount = getattr(self.simulation, "resize_amount", None)
 
-        if resize_amount in (None, 0):
+        if resize_amount in (None, 0) or pix_mic_conv is None:
             spatial_scale = 1.0
-        elif pix_mic_conv is None:
-            spatial_scale = 1.0
+            spatial_unit = "pixel"
         else:
             spatial_scale = float(pix_mic_conv) / float(resize_amount)
+            spatial_unit = "micrometer"
 
         start_frame = None
         end_frame = None
@@ -279,10 +281,10 @@ class Lineage:
                 }
                 for name, dtype, unit in (
                     ("t", "int64", "frame"),
-                    ("y", "float64", "micrometer"),
-                    ("x", "float64", "micrometer"),
-                    ("length", "float64", "micrometer"),
-                    ("width", "float64", "micrometer"),
+                    ("y", "float64", spatial_unit),
+                    ("x", "float64", spatial_unit),
+                    ("length", "float64", spatial_unit),
+                    ("width", "float64", spatial_unit),
                 )
             },
             edge_props_metadata={},
@@ -293,7 +295,7 @@ class Lineage:
             store,
             metadata=metadata,
             axis_names=["t", "y", "x"],
-            axis_units=["frame", "micrometer", "micrometer"],
+            axis_units=["frame", spatial_unit, spatial_unit],
             axis_types=["time", "space", "space"],
             zarr_format=zarr_format,
             overwrite=overwrite,

--- a/SyMBac/renderer.py
+++ b/SyMBac/renderer.py
@@ -1453,6 +1453,14 @@ class Renderer:
                 image_path = os.path.join(images_dir, f"frame_{frame_idx:05d}.{image_ext}")
                 mask_path = os.path.join(masks_dir, f"frame_{frame_idx:05d}.{image_ext}")
                 frame_mask_dtype = _resolve_mask_export_dtype(mask, requested_mask_dtype)
+                if image_ext == "png" and frame_mask_dtype not in {
+                    np.dtype(np.uint8),
+                    np.dtype(np.uint16),
+                }:
+                    raise ValueError(
+                        f"PNG masks support at most uint16 without loss, got "
+                        f"{frame_mask_dtype.name}; use TIFF instead."
+                    )
 
                 if image_ext == "png":
                     Image.fromarray(skimage.img_as_uint(rescale_intensity(syn_image))).save(image_path)

--- a/SyMBac/renderer.py
+++ b/SyMBac/renderer.py
@@ -102,6 +102,34 @@ def _relabel_instance_masks(mask, superres_mask, mask_dtype):
     return relabeled_masks
 
 
+def _is_binary_mask(mask):
+    mask = np.asarray(mask)
+    if mask.dtype == np.bool_:
+        return True
+    return bool(np.isin(np.unique(mask), (0, 1)).all())
+
+
+def _resolve_mask_export_dtype(mask, requested_dtype=None):
+    mask = np.asarray(mask)
+    min_label = int(mask.min())
+    max_label = int(mask.max())
+    if min_label < 0:
+        raise ValueError(f"Mask labels must be non-negative, got {min_label}.")
+
+    if requested_dtype is None:
+        return np.dtype(np.min_scalar_type(max_label))
+
+    mask_dtype = np.dtype(requested_dtype)
+    if mask_dtype.kind not in "iu":
+        raise TypeError(f"mask_dtype must be an integer dtype, got {mask_dtype.name}.")
+    limits = np.iinfo(mask_dtype)
+    if min_label < limits.min or max_label > limits.max:
+        raise ValueError(
+            f"Mask label range [{min_label}, {max_label}] cannot be represented by {mask_dtype.name}."
+        )
+    return mask_dtype
+
+
 def convolve_rescale(image, kernel, rescale_factor, rescale_int):
     """
     Convolves an image with a kernel, and rescales it to the correct size.
@@ -565,7 +593,7 @@ class Renderer:
             expanded_mask, 1 / self.simulation.resize_amount,
             anti_aliasing=False, preserve_range=True, order=0
         )
-        if len(np.unique(expanded_mask_resized)) > 2:
+        if not _is_binary_mask(expanded_mask_resized):
             _, mask = make_images_same_shape(
                 self.real_image, expanded_mask_resized, rescale_int=False
             )
@@ -792,7 +820,7 @@ class Renderer:
         expanded_mask_resized = rescale(expanded_mask, 1 / self.simulation.resize_amount, anti_aliasing=False,
                                         preserve_range=True,
                                         order=0)
-        if len(np.unique(expanded_mask_resized)) > 2:
+        if not _is_binary_mask(expanded_mask_resized):
             _, expanded_mask_resized_reshaped = make_images_same_shape(self.real_image, expanded_mask_resized,
                                                                        rescale_int=False)
         else:
@@ -870,7 +898,16 @@ class Renderer:
             plt.show()
             plt.close()
         else:
-            _, superres_mask = make_images_same_shape(np.zeros((self.real_image.shape[0]*self.simulation.resize_amount,self.real_image.shape[1]*self.simulation.resize_amount)), expanded_mask, rescale_int=False)
+            _, superres_mask = make_images_same_shape(
+                np.zeros(
+                    (
+                        self.real_image.shape[0] * self.simulation.resize_amount,
+                        self.real_image.shape[1] * self.simulation.resize_amount,
+                    )
+                ),
+                expanded_mask,
+                rescale_int=_is_binary_mask(expanded_mask),
+            )
             return noisy_img, expanded_mask_resized_reshaped.astype(int), superres_mask.astype(int)
             #return noisy_img, expanded_mask_resized_reshaped.astype(int)
 
@@ -1279,7 +1316,7 @@ class Renderer:
         sample_amount=0.02,
         n_series=1,
         frames_per_series=None,
-        mask_dtype=np.uint16,
+        mask_dtype=None,
         export_geff=True,
         seed=None,
         n_jobs=1,
@@ -1326,7 +1363,7 @@ class Renderer:
         if image_format not in {"tif", "tiff", "png"}:
             raise ValueError("image_format must be one of: 'tif', 'tiff', 'png'.")
         image_ext = "png" if image_format == "png" else "tiff"
-        mask_dtype = np.dtype(mask_dtype)
+        requested_mask_dtype = None if mask_dtype is None else np.dtype(mask_dtype)
 
         if seed is not None:
             random.seed(seed)
@@ -1373,7 +1410,9 @@ class Renderer:
             "simulation_frame_start": int(scene_nos[0]),
             "simulation_frame_end_exclusive": int(scene_nos[-1] + 1),
             "sample_amount": float(sample_amount),
-            "mask_dtype": str(mask_dtype),
+            "mask_dtype": (
+                "inferred" if requested_mask_dtype is None else str(requested_mask_dtype)
+            ),
             "image_format": image_ext,
             "series": [],
         }
@@ -1413,19 +1452,21 @@ class Renderer:
                 )
                 image_path = os.path.join(images_dir, f"frame_{frame_idx:05d}.{image_ext}")
                 mask_path = os.path.join(masks_dir, f"frame_{frame_idx:05d}.{image_ext}")
+                frame_mask_dtype = _resolve_mask_export_dtype(mask, requested_mask_dtype)
 
                 if image_ext == "png":
                     Image.fromarray(skimage.img_as_uint(rescale_intensity(syn_image))).save(image_path)
-                    Image.fromarray(mask.astype(mask_dtype, copy=False)).save(mask_path)
+                    Image.fromarray(mask.astype(frame_mask_dtype, copy=False)).save(mask_path)
                 else:
                     imwrite(image_path, skimage.img_as_uint(rescale_intensity(syn_image)))
-                    imwrite(mask_path, mask.astype(mask_dtype, copy=False))
+                    imwrite(mask_path, mask.astype(frame_mask_dtype, copy=False))
 
                 return {
                     "frame_idx": int(frame_idx),
                     "simulation_frame_idx": int(scene_no),
                     "image_path": os.path.relpath(image_path, series_dir),
                     "mask_path": os.path.relpath(mask_path, series_dir),
+                    "mask_dtype": frame_mask_dtype.name,
                 }
 
             if n_jobs == 1:

--- a/tests/test_geff_export.py
+++ b/tests/test_geff_export.py
@@ -199,7 +199,7 @@ def test_lineage_to_geff_round_trips_standard_metadata(tmp_path):
     lineage = Lineage(sim)
 
     store = tmp_path / "lineage.geff"
-    lineage.to_geff(store, overwrite=True)
+    lineage.to_geff(store, frame_range=(2, 3), overwrite=True)
     _, metadata = geff.read(
         store,
         data_validation=ValidationConfig(graph=True, tracklet=True, lineage=True),

--- a/tests/test_geff_export.py
+++ b/tests/test_geff_export.py
@@ -2,7 +2,10 @@ import json
 import sys
 import types
 
+import geff
 import numpy as np
+import pytest
+from geff.validate.data import ValidationConfig
 from tifffile import imread
 
 from SyMBac.lineage import Lineage
@@ -38,46 +41,7 @@ class _CellStub:
         self.generation = generation
 
 
-def test_lineage_to_geff_exports_filtered_temporal_graph(monkeypatch):
-    sim = _SimulationStub(
-        [
-            [_CellStub(mask_label=1, t=0, mother_mask_label=None, position=(10, 20))],
-            [
-                _CellStub(mask_label=1, t=1, mother_mask_label=None, position=(11, 21)),
-                _CellStub(mask_label=2, t=1, mother_mask_label=1, position=(12, 22), generation=1),
-            ],
-        ]
-    )
-    lineage = Lineage(sim)
-
-    captured = {}
-
-    def _fake_write(graph, store, **kwargs):
-        captured["graph"] = graph
-        captured["store"] = store
-        captured["kwargs"] = kwargs
-
-    monkeypatch.setitem(sys.modules, "geff", types.SimpleNamespace(write=_fake_write))
-
-    lineage.to_geff("dummy_store", frame_range=(1, 2), overwrite=True)
-
-    graph = captured["graph"]
-    kwargs = captured["kwargs"]
-
-    assert captured["store"] == "dummy_store"
-    assert kwargs["axis_names"] == ["t", "y", "x"]
-    assert kwargs["axis_types"] == ["time", "space", "space"]
-    assert kwargs["track_node_props"] == {"tracklet": "tracklet_id", "lineage": "lineage_id"}
-
-    node_data = list(graph.nodes(data=True))
-    assert len(node_data) == 2
-    seg_ids = {attrs["seg_id"] for _, attrs in node_data}
-    assert seg_ids == {1, 2}
-    assert {attrs["t"] for _, attrs in node_data} == {1}
-    assert len(graph.edges()) == 1
-
-
-def test_generate_timeseries_training_data_writes_uint16_tiff_masks(tmp_path):
+def _timeseries_renderer(mask_label):
     renderer = Renderer.__new__(Renderer)
     renderer.additional_real_images = None
     renderer.params = types.SimpleNamespace(
@@ -104,11 +68,74 @@ def test_generate_timeseries_training_data_writes_uint16_tiff_masks(tmp_path):
 
     def _fake_generate_test_comparison(**_kwargs):
         image = np.array([[0.0, 1.0], [0.5, 0.2]], dtype=np.float32)
-        mask = np.array([[0, 300], [1, 2]], dtype=np.int32)
+        mask = np.array([[0, mask_label], [1, 2]], dtype=np.int64)
         superres = np.zeros_like(mask)
         return image, mask, superres
 
     renderer.generate_test_comparison = _fake_generate_test_comparison
+    return renderer
+
+
+def test_lineage_to_geff_exports_filtered_temporal_graph(monkeypatch):
+    sim = _SimulationStub(
+        [
+            [_CellStub(mask_label=1, t=0, mother_mask_label=None, position=(10, 20))],
+            [
+                _CellStub(mask_label=1, t=1, mother_mask_label=None, position=(11, 21)),
+                _CellStub(mask_label=2, t=1, mother_mask_label=1, position=(12, 22), generation=1),
+            ],
+        ]
+    )
+    lineage = Lineage(sim)
+
+    captured = {}
+
+    def _fake_write(graph, store, **kwargs):
+        captured["graph"] = graph
+        captured["store"] = store
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setitem(
+        sys.modules,
+        "geff",
+        types.SimpleNamespace(write=_fake_write, GeffMetadata=geff.GeffMetadata),
+    )
+
+    lineage.to_geff("dummy_store", frame_range=(1, 2), overwrite=True)
+
+    graph = captured["graph"]
+    kwargs = captured["kwargs"]
+
+    assert captured["store"] == "dummy_store"
+    assert kwargs["axis_names"] == ["t", "y", "x"]
+    assert kwargs["axis_types"] == ["time", "space", "space"]
+    assert kwargs["axis_units"] == ["frame", "micrometer", "micrometer"]
+    assert kwargs["metadata"].track_node_props == {
+        "tracklet": "tracklet_id",
+        "lineage": "lineage_id",
+    }
+
+    node_data = list(graph.nodes(data=True))
+    assert len(node_data) == 2
+    seg_ids = {attrs["seg_id"] for _, attrs in node_data}
+    assert seg_ids == {1, 2}
+    assert {attrs["t"] for _, attrs in node_data} == {1}
+    assert len(graph.edges()) == 1
+    daughter = next(attrs for _, attrs in node_data if attrs["seg_id"] == 2)
+    assert daughter["x"] == pytest.approx(0.6)
+    assert daughter["y"] == pytest.approx(1.1)
+    assert daughter["length"] == pytest.approx(0.15)
+    assert daughter["width"] == pytest.approx(0.05)
+
+
+@pytest.mark.parametrize(
+    ("mask_label", "expected_dtype"),
+    [(300, np.uint16), (65536, np.uint32)],
+)
+def test_generate_timeseries_training_data_promotes_inferred_mask_dtype(
+    tmp_path, mask_label, expected_dtype
+):
+    renderer = _timeseries_renderer(mask_label)
 
     out_dir = tmp_path / "tracking_data"
     metadata = renderer.generate_timeseries_training_data(
@@ -132,22 +159,62 @@ def test_generate_timeseries_training_data_writes_uint16_tiff_masks(tmp_path):
     assert [frame["simulation_frame_idx"] for frame in manifest["frames"]] == [1, 2]
 
     mask_0 = imread(out_dir / "series_000" / "masks" / "frame_00000.tiff")
-    assert mask_0.dtype == np.uint16
-    assert int(mask_0.max()) == 300
+    assert mask_0.dtype == expected_dtype
+    assert int(mask_0.max()) == mask_label
+    assert metadata["mask_dtype"] == "inferred"
+    assert manifest["frames"][0]["mask_dtype"] == np.dtype(expected_dtype).name
 
 
-def test_lineage_to_geff_falls_back_when_track_node_props_unsupported(monkeypatch):
-    sim = _SimulationStub([[ _CellStub(mask_label=1, t=0, mother_mask_label=None, position=(1, 2)) ]])
+def test_generate_timeseries_training_data_rejects_insufficient_explicit_dtype(tmp_path):
+    renderer = _timeseries_renderer(256)
+
+    with pytest.raises(ValueError, match="label range.*uint8"):
+        renderer.generate_timeseries_training_data(
+            save_dir=str(tmp_path / "tracking_data"),
+            burn_in=1,
+            sample_amount=0.0,
+            n_series=1,
+            frames_per_series=1,
+            mask_dtype=np.uint8,
+            export_geff=False,
+            seed=7,
+            image_format="tiff",
+        )
+
+
+def test_lineage_to_geff_round_trips_standard_metadata(tmp_path):
+    sim = _SimulationStub(
+        [
+            [_CellStub(mask_label=1, t=0, position=(1, 2))],
+            [
+                _CellStub(mask_label=1, t=1, position=(1, 2)),
+                _CellStub(mask_label=2, t=1, mother_mask_label=1, position=(1, 2)),
+            ],
+            [
+                _CellStub(mask_label=1, t=2, position=(1, 2)),
+                _CellStub(mask_label=2, t=2, mother_mask_label=1, position=(1, 2)),
+            ],
+        ]
+    )
     lineage = Lineage(sim)
 
-    calls = {"count": 0}
+    store = tmp_path / "lineage.geff"
+    lineage.to_geff(store, overwrite=True)
+    _, metadata = geff.read(
+        store,
+        data_validation=ValidationConfig(graph=True, tracklet=True, lineage=True),
+    )
 
-    def _fake_write(_graph, _store, **kwargs):
-        calls["count"] += 1
-        if "track_node_props" in kwargs:
-            raise TypeError("NxBackend.write() got an unexpected keyword argument 'track_node_props'")
-        return None
-
-    monkeypatch.setitem(sys.modules, "geff", types.SimpleNamespace(write=_fake_write))
-    lineage.to_geff("dummy_store_fallback", overwrite=True)
-    assert calls["count"] == 2
+    assert metadata.track_node_props == {
+        "tracklet": "tracklet_id",
+        "lineage": "lineage_id",
+    }
+    assert [axis.unit for axis in metadata.axes] == [
+        "frame",
+        "micrometer",
+        "micrometer",
+    ]
+    assert metadata.node_props_metadata["x"].unit == "micrometer"
+    assert metadata.node_props_metadata["y"].unit == "micrometer"
+    assert metadata.node_props_metadata["length"].unit == "micrometer"
+    assert metadata.node_props_metadata["width"].unit == "micrometer"

--- a/tests/test_geff_export.py
+++ b/tests/test_geff_export.py
@@ -182,6 +182,22 @@ def test_generate_timeseries_training_data_rejects_insufficient_explicit_dtype(t
         )
 
 
+def test_generate_timeseries_training_data_rejects_uint32_png_masks(tmp_path):
+    renderer = _timeseries_renderer(65536)
+
+    with pytest.raises(ValueError, match="PNG.*uint16.*TIFF"):
+        renderer.generate_timeseries_training_data(
+            save_dir=str(tmp_path / "tracking_data"),
+            burn_in=1,
+            sample_amount=0.0,
+            n_series=1,
+            frames_per_series=1,
+            export_geff=False,
+            seed=7,
+            image_format="png",
+        )
+
+
 def test_lineage_to_geff_round_trips_standard_metadata(tmp_path):
     sim = _SimulationStub(
         [
@@ -218,3 +234,23 @@ def test_lineage_to_geff_round_trips_standard_metadata(tmp_path):
     assert metadata.node_props_metadata["y"].unit == "micrometer"
     assert metadata.node_props_metadata["length"].unit == "micrometer"
     assert metadata.node_props_metadata["width"].unit == "micrometer"
+
+
+def test_lineage_to_geff_uses_pixel_units_without_spatial_calibration(tmp_path):
+    sim = _SimulationStub(
+        [[_CellStub(mask_label=1, t=0, position=(10, 20), length=3, width=1)]],
+        pix_mic_conv=None,
+    )
+    store = tmp_path / "lineage.geff"
+
+    Lineage(sim).to_geff(store, overwrite=True)
+    graph, metadata = geff.read(store)
+
+    node = next(iter(graph.nodes.values()))
+    assert node["x"] == 10
+    assert node["y"] == 20
+    assert node["length"] == 3
+    assert node["width"] == 1
+    assert [axis.unit for axis in metadata.axes] == ["frame", "pixel", "pixel"]
+    assert metadata.node_props_metadata["length"].unit == "pixel"
+    assert metadata.node_props_metadata["width"].unit == "pixel"

--- a/tests/test_lineage_compat.py
+++ b/tests/test_lineage_compat.py
@@ -17,6 +17,14 @@ class SlotOnlyCell:
         self.t = t
 
 
+class DivisionAwareCell(SlotOnlyCell):
+    __slots__ = ("just_divided",)
+
+    def __init__(self, mask_label, t, mother_mask_label=None, just_divided=False):
+        super().__init__(mask_label, t, mother_mask_label)
+        self.just_divided = just_divided
+
+
 def _edge_set(edgelist):
     return {tuple(edge) for edge in edgelist.tolist()}
 
@@ -42,14 +50,19 @@ def test_lineage_handles_slot_only_cells():
 def test_lineage_adds_persistent_mother_metadata_edge_only_at_division_frame():
     sim = SimulationStub(
         [
-            [SlotOnlyCell(mask_label=1, t=0)],
+            [DivisionAwareCell(mask_label=1, t=0)],
             [
-                SlotOnlyCell(mask_label=1, t=1),
-                SlotOnlyCell(mask_label=2, t=1, mother_mask_label=1),
+                DivisionAwareCell(mask_label=1, t=1, just_divided=True),
+                DivisionAwareCell(
+                    mask_label=2,
+                    t=1,
+                    mother_mask_label=1,
+                    just_divided=True,
+                ),
             ],
             [
-                SlotOnlyCell(mask_label=1, t=2),
-                SlotOnlyCell(mask_label=2, t=2, mother_mask_label=1),
+                DivisionAwareCell(mask_label=1, t=2),
+                DivisionAwareCell(mask_label=2, t=2, mother_mask_label=1),
             ],
         ]
     )
@@ -58,6 +71,21 @@ def test_lineage_adds_persistent_mother_metadata_edge_only_at_division_frame():
 
     assert lineage.temporal_lineage_graph.has_edge((1, 1), (2, 1))
     assert not lineage.temporal_lineage_graph.has_edge((1, 2), (2, 2))
+
+
+def test_lineage_does_not_treat_late_first_observation_as_division():
+    sim = SimulationStub(
+        [
+            [
+                DivisionAwareCell(mask_label=1, t=5),
+                DivisionAwareCell(mask_label=2, t=5, mother_mask_label=1),
+            ]
+        ]
+    )
+
+    lineage = Lineage(sim)
+
+    assert not lineage.temporal_lineage_graph.has_edge((1, 5), (2, 5))
 
 
 def test_lineage_rejects_duplicate_mask_label_and_time():

--- a/tests/test_lineage_compat.py
+++ b/tests/test_lineage_compat.py
@@ -39,6 +39,36 @@ def test_lineage_handles_slot_only_cells():
     assert lineage.temporal_lineage_graph.has_edge((1, 1), (2, 1))
 
 
+def test_lineage_adds_persistent_mother_metadata_edge_only_at_division_frame():
+    sim = SimulationStub(
+        [
+            [SlotOnlyCell(mask_label=1, t=0)],
+            [
+                SlotOnlyCell(mask_label=1, t=1),
+                SlotOnlyCell(mask_label=2, t=1, mother_mask_label=1),
+            ],
+            [
+                SlotOnlyCell(mask_label=1, t=2),
+                SlotOnlyCell(mask_label=2, t=2, mother_mask_label=1),
+            ],
+        ]
+    )
+
+    lineage = Lineage(sim)
+
+    assert lineage.temporal_lineage_graph.has_edge((1, 1), (2, 1))
+    assert not lineage.temporal_lineage_graph.has_edge((1, 2), (2, 2))
+
+
+def test_lineage_rejects_duplicate_mask_label_and_time():
+    sim = SimulationStub(
+        [[SlotOnlyCell(mask_label=1, t=0), SlotOnlyCell(mask_label=1, t=0)]]
+    )
+
+    with pytest.raises(ValueError, match="Duplicate detection.*mask_label=1.*time=0"):
+        Lineage(sim)
+
+
 def test_lineage_handles_mixed_frames_and_missing_mother_node():
     sim = SimulationStub(
         [

--- a/tests/test_renderer_mask_export.py
+++ b/tests/test_renderer_mask_export.py
@@ -61,6 +61,52 @@ def test_mask_is_binary_only_for_boolean_or_zero_one_labels(mask, expected):
     assert renderer_module._is_binary_mask(mask) is expected
 
 
+def test_generate_test_comparison_preserves_sparse_base_and_superres_labels(monkeypatch):
+    renderer = Renderer.__new__(Renderer)
+    renderer.simulation = SimpleNamespace(
+        OPL_scenes=[np.arange(16, dtype=float).reshape(4, 4)],
+        masks=[np.zeros((4, 4), dtype=np.uint16)],
+        resize_amount=1,
+        pix_mic_conv=0.1,
+    )
+    renderer.real_image = np.arange(4, dtype=float).reshape(2, 2)
+    renderer.PSF = SimpleNamespace(
+        mode="fluorescence",
+        kernel=np.ones((1, 1)),
+        radius=1,
+        scale=1,
+        NA=1,
+        n=1,
+        apo_sigma=1,
+        wavelength=1,
+    )
+    renderer.camera = None
+    renderer.image_params = (0, 0, 0, np.zeros(3), 0, 0, 0, np.zeros(3))
+    renderer.error_params = tuple([] for _ in range(8))
+    renderer.x_border_expansion_coefficient = 1
+    renderer.y_border_expansion_coefficient = 1
+
+    expanded_mask = np.zeros((4, 4), dtype=np.uint16)
+    expanded_mask[2:, :2] = np.array([[0, 300], [300, 0]], dtype=np.uint16)
+    renderer.generate_PC_OPL = MethodType(
+        lambda self, **kwargs: (
+            np.arange(16, dtype=float).reshape(4, 4),
+            np.ones((4, 4), dtype=float),
+            expanded_mask,
+        ),
+        renderer,
+    )
+    monkeypatch.setattr(renderer_module, "random_noise", lambda image, **kwargs: image)
+
+    _, mask, superres_mask = renderer.generate_test_comparison(
+        match_histogram=False,
+        match_noise=False,
+    )
+
+    assert set(np.unique(mask)) == {0, 300}
+    assert np.array_equal(mask, superres_mask)
+
+
 def test_generate_training_data_relabels_instances_before_uint8_export(tmp_path):
     mask = np.array(
         [

--- a/tests/test_renderer_mask_export.py
+++ b/tests/test_renderer_mask_export.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
+import SyMBac.renderer as renderer_module
 from SyMBac.renderer import Renderer
 
 
@@ -46,6 +47,18 @@ def _render_parameters():
         "noise_match_bools": [False],
         "fourier_match_bools": [False],
     }
+
+
+@pytest.mark.parametrize(
+    ("mask", "expected"),
+    [
+        (np.array([[False, True]], dtype=bool), True),
+        (np.array([[0, 1]], dtype=np.uint16), True),
+        (np.array([[0, 300]], dtype=np.uint16), False),
+    ],
+)
+def test_mask_is_binary_only_for_boolean_or_zero_one_labels(mask, expected):
+    assert renderer_module._is_binary_mask(mask) is expected
 
 
 def test_generate_training_data_relabels_instances_before_uint8_export(tmp_path):


### PR DESCRIPTION
## What changed

- Preserve sparse mask labels during renderer resizing and keep base and super-resolution masks aligned.
- Infer a lossless time-series mask dtype, reject explicitly insufficient dtypes, and reject PNG output when labels need more than `uint16`.
- Add lineage division edges only on the recorded division frame and reject duplicate `(mask_label, time)` detections.
- Write GEFF track/lineage metadata through `GeffMetadata`, use consistent spatial units for positions and cell dimensions, and keep sliced exports valid under GEFF track and lineage validation.
- Add focused regression tests for sparse labels, dtype overflow, division timing, duplicate detections, units, metadata, and sliced frame windows.

## Why

Sparse instance IDs could be normalized as binary masks, and time-series casts could silently wrap an object label to background. Persistent mother metadata also created repeated division edges. Finally, `track_node_props` was passed as a free keyword that current GEFF silently ignored, while length and width were left in pixels even when positions were converted to micrometres.

The legacy `.mother` fallback was not restored because the current repository explicitly removed that API and rejects legacy simulation artifacts.

## Validation

- `pixi run pytest -q tests/test_renderer_mask_export.py tests/test_lineage_compat.py tests/test_geff_export.py` — 18 passed
- `pixi run pytest -q` — 74 passed
- GEFF round-trip tests enable graph, tracklet, and lineage data validation, including a frame window that starts after division.

The only test warning is the existing CPU fallback warning when neither CuPy nor PyTorch is available.
