### PR TITLE
Fix optional colony imports and 3-D rendering

### DIFF
--- a/SyMBac/PSF.py
+++ b/SyMBac/PSF.py
@@ -99,6 +99,11 @@ class PSF_generator:
         self.mode = mode
         self.condenser = condenser
         self.pz = pz
+        if "3d fluo" in self.mode.lower():
+            if working_distance is None:
+                working_distance = 150.0
+            if not np.isfinite(working_distance) or working_distance <= 0:
+                raise ValueError("working_distance must be a positive finite value")
         self.working_distance = working_distance
         if condenser:
             self.W, self.R, self.diameter = self.get_condensers()[condenser]

--- a/SyMBac/colony_renderer.py
+++ b/SyMBac/colony_renderer.py
@@ -1,7 +1,6 @@
 import random
 from itertools import cycle, islice
 import os
-import ray
 import numpy as np
 import noise
 from PIL import Image
@@ -123,6 +122,13 @@ class ColonyRenderer:
         return convolved
 
     def generate_random_samples_ray(self, n, roll_prob, savedir, GPUs = (0,) , n_jobs = 1, gpu_fraction=1, batch_size = 20):
+        try:
+            import ray
+        except ImportError as error:
+            raise ImportError(
+                "Ray is required for ColonyRenderer.generate_random_samples_ray"
+            ) from error
+
         n_GPUs = len(GPUs)
         #if n_GPUs > 1:
         #    n_jobs = n_GPUs

--- a/SyMBac/colony_renderer.py
+++ b/SyMBac/colony_renderer.py
@@ -24,6 +24,15 @@ except ImportError:
     _HAS_CUPY = False
 from joblib import Parallel, delayed
 
+
+def _as_png_uint16(image):
+    scaled = rescale_intensity(
+        np.asarray(image, dtype=np.float32),
+        out_range=(0, 1),
+    )
+    return np.round(scaled * np.iinfo(np.uint16).max).astype(np.uint16)
+
+
 class ColonyRenderer:
     def __init__(self, simulation, PSF, camera = None, force_2D = False):
         self.simulation = simulation
@@ -42,6 +51,8 @@ class ColonyRenderer:
 
         if "3d" in self.PSF.mode.lower():
             self.OPL_dirs = sorted(glob(f"{simulation.fluorescent_projections_dir}/*.tif*"))
+        elif "fluo" in self.PSF.mode.lower():
+            self.OPL_dirs = sorted(glob(f"{simulation.fluorescence_dir}/*.png"))
 
     def perlin_generator(self, shape, scale = 5, octaves = 10, persistence = 1.9, lacunarity = 1.8):
 
@@ -92,7 +103,11 @@ class ColonyRenderer:
 
         if "3d" in self.PSF.mode.lower():
             self.PSF.z_height = scene.shape[0]
-            #self.PSF.calculate_PSF()
+            if kernel.shape[0] != scene.shape[0]:
+                self.PSF.calculate_PSF()
+                kernel = self.PSF.kernel
+            if kernel.shape[0] != scene.shape[0]:
+                raise ValueError("3D PSF and scene must have the same z dimension")
             kernel = self.PSF.kernel / np.sum(self.PSF.kernel)
 
             if self.force_2D:
@@ -102,7 +117,10 @@ class ColonyRenderer:
                 convolved = convolve_rescale(scene, kernel, 1/self.resize_amount, rescale_int=False)
             else:
                 convolved = np.array(
-                    [convolve_rescale(scene_slice, PSF_slice/np.sum(PSF_slice), 1/self.resize_amount, rescale_int=False) for scene_slice, PSF_slice in zip(scene, kernel)]
+                    [convolve_rescale(scene_slice, PSF_slice, 1/self.resize_amount, rescale_int=False) for scene_slice, PSF_slice in zip(scene, kernel)]
+                )
+                convolved = rescale_intensity(
+                    convolved.astype(np.float32), out_range=(0, 1)
                 )
         else:
             convolved = convolve_rescale(scene, kernel, 1/self.resize_amount, rescale_int=False)
@@ -164,10 +182,10 @@ class ColonyRenderer:
                         rescaled_mask = np.roll(rescaled_mask, amount, axis=n_axis_to_roll)
 
                     if "3d" in self.PSF.mode.lower():
-                        tifffile.imwrite(f"{savedir}/synth_imgs/{str(i).zfill(zero_pads)}.tif", sample, compression='zlib', compressionargs={'level': 8})
+                        tifffile.imwrite(f"{savedir}/synth_imgs/{str(j).zfill(zero_pads)}.tif", sample, compression='zlib', compressionargs={'level': 8})
                     else:
-                        Image.fromarray(sample).save(f"{savedir}/synth_imgs/{str(i).zfill(zero_pads)}.png")
-                    Image.fromarray(rescaled_mask).save(f"{savedir}/masks/{str(i).zfill(zero_pads)}.png")
+                        Image.fromarray(_as_png_uint16(sample)).save(f"{savedir}/synth_imgs/{str(j).zfill(zero_pads)}.png")
+                    Image.fromarray(rescaled_mask).save(f"{savedir}/masks/{str(j).zfill(zero_pads)}.png")
 
             if _HAS_CUPY:
                 s = cp.cuda.Stream(non_blocking=True)
@@ -244,10 +262,10 @@ class ColonyRenderer:
                         rescaled_mask = np.roll(rescaled_mask, amount, axis=n_axis_to_roll)
 
                     if "3d" in self.PSF.mode.lower():
-                        tifffile.imwrite(f"{savedir}/synth_imgs/{str(i).zfill(zero_pads)}.tif", sample, compression='zlib', compressionargs={'level': 8})
+                        tifffile.imwrite(f"{savedir}/synth_imgs/{str(j).zfill(zero_pads)}.tif", sample, compression='zlib', compressionargs={'level': 8})
                     else:
-                        Image.fromarray(sample).save(f"{savedir}/synth_imgs/{str(i).zfill(zero_pads)}.png")
-                    Image.fromarray(rescaled_mask).save(f"{savedir}/masks/{str(i).zfill(zero_pads)}.png")
+                        Image.fromarray(_as_png_uint16(sample)).save(f"{savedir}/synth_imgs/{str(j).zfill(zero_pads)}.png")
+                    Image.fromarray(rescaled_mask).save(f"{savedir}/masks/{str(j).zfill(zero_pads)}.png")
 
                     #if j > n:
                     #    break

--- a/SyMBac/colony_simulation.py
+++ b/SyMBac/colony_simulation.py
@@ -8,8 +8,21 @@ from joblib import Parallel, delayed
 from PIL import Image
 from skimage.transform import rotate
 from natsort import natsorted
-from SyMBac.drawing import raster_cell, OPL_to_FL, clean_up_mask, convert_to_3D, crop_image, get_crop_bounds_2D
+from SyMBac.drawing import raster_cell, OPL_to_FL, convert_to_3D, crop_image, get_crop_bounds_2D
 import tifffile
+
+
+def _compose_label_mask(mask, cell_pixels, cell_label):
+    composed = mask.copy()
+    composed[cell_pixels] = cell_label
+    return composed
+
+
+def _scene_position(position, scene_shape):
+    offset_y, offset_x = np.ceil(np.asarray(scene_shape) / 2).astype(int)
+    position_x, position_y = np.asarray(position).astype(int)
+    return position_x + offset_x, position_y + offset_y
+
 
 class ColonySimulation:
     def __init__(self, cellmodeller_model, max_cells, pix_mic_conv, resize_amount, save_dir):
@@ -129,6 +142,7 @@ class ColonySimulation:
         return self.scene_shape
 
     def draw_scene(self, cellmodeller_properties, save = False, savename = False, return_save = False, FL = False, density = 1, random_distribution = "uniform", distribution_args = (1,1), as_3D = False, crop=False, crop_pad=0):
+        """Draw a colony scene, returning a 3-D OPL volume when ``as_3D`` is true."""
         space = np.zeros(self.scene_shape)
         fluorescence_space = np.zeros(self.scene_shape)
         #sample OPL cell
@@ -148,9 +162,7 @@ class ColonySimulation:
             density_modifiers = [x if x > 0 else np.mean(density_modifiers) for x in density_modifiers]
         for c in range(len(cellmodeller_properties)):
             position = cellmodeller_properties[c][3]
-            offset = np.ceil(np.mean(self.scene_shape) / 2).astype(int)
-            x = np.array(position).astype(int)[0] + offset
-            y = np.array(position).astype(int)[1] + offset
+            x, y = _scene_position(position, self.scene_shape)
 
 
             OPL_cell = raster_cell(cellmodeller_properties[c][0], cellmodeller_properties[c][1], separation=0)
@@ -189,30 +201,37 @@ class ColonySimulation:
                     y - cell_y:y + cell_y + offset_y,
                     x - cell_x:x + cell_x + offset_x
                 ] += (rotated_OPL_cell)
-            mask[
+            mask_slice = np.s_[
                 y - cell_y:y + cell_y + offset_y,
                 x - cell_x:x + cell_x + offset_x
-            ] += ((rotated_OPL_cell) > 1) * mask_counter
+            ]
+            mask[mask_slice] = _compose_label_mask(
+                mask[mask_slice], rotated_OPL_cell > 0, mask_counter
+            )
             mask_counter += 1
-        mask =  clean_up_mask(mask)
 
         if crop:
 
             (start_row, stop_row), (start_col, stop_col) = get_crop_bounds_2D(mask)
 
-            space = crop_image(space, (start_row, stop_row), (start_col, stop_col), pad=crop_pad)
+            if as_3D:
+                space_3D = crop_image(space_3D, (start_row, stop_row), (start_col, stop_col), pad=crop_pad)
+            else:
+                space = crop_image(space, (start_row, stop_row), (start_col, stop_col), pad=crop_pad)
             mask = crop_image(mask, (start_row, stop_row), (start_col, stop_col), pad=crop_pad)
             if FL:
-                fluorescence_space = crop_image(fluorescence_space, (start_row, stop_row), (start_col, stop_col), pad=crop_pad)
                 if as_3D:
                     fluorescence_space_3D = crop_image(fluorescence_space_3D, (start_row, stop_row), (start_col, stop_col), pad = crop_pad)
-                    space_3D = crop_image(space_3D, (start_row, stop_row), (start_col, stop_col), pad=crop_pad)
+                else:
+                    fluorescence_space = crop_image(fluorescence_space, (start_row, stop_row), (start_col, stop_col), pad=crop_pad)
         
 
         if save and not savename:
             raise Exception("Add a savename if you wish to save")
         if save and savename:
-            im = Image.fromarray(space.astype(np.uint8))
+            rendered_space = space_3D if as_3D else space
+            preview = np.sum(space_3D, axis=0) if as_3D else space
+            im = Image.fromarray(preview.astype(np.uint8))
             im.save(f"data/scenes/{savename}.png")
             im = Image.fromarray(mask.astype(np.uint16))
             im.save(f"data/masks/{savename}.png")
@@ -230,11 +249,11 @@ class ColonySimulation:
 
 
             if return_save:
-                return space, mask
+                return rendered_space, mask
             else:
                 return None
         else:
-            return space, mask
+            return (space_3D if as_3D else space), mask
 
     def draw_OPL_from_idx(self,idx, FL = False, density = 1, random_distribution = "uniform", distribution_args = (0.99, 1.01)):
         cellmodeller_properties = self.get_cellmodeller_properties(

--- a/SyMBac/colony_simulation.py
+++ b/SyMBac/colony_simulation.py
@@ -147,9 +147,12 @@ class ColonySimulation:
         fluorescence_space = np.zeros(self.scene_shape)
         #sample OPL cell
         if as_3D:
-            OPL_cell = raster_cell(cellmodeller_properties[0][0], cellmodeller_properties[0][1], separation=0)
-            OPL_cell_3D = convert_to_3D(OPL_cell)
-            n_layers = OPL_cell_3D.shape[0]
+            OPL_cells = [
+                raster_cell(properties[0], properties[1], separation=0)
+                for properties in cellmodeller_properties
+            ]
+            OPL_cells_3D = [convert_to_3D(cell) for cell in OPL_cells]
+            n_layers = max(cell.shape[0] for cell in OPL_cells_3D)
             space_3D = np.zeros((n_layers,) + self.scene_shape)
             fluorescence_space_3D = np.zeros((n_layers,) + self.scene_shape)
 
@@ -164,11 +167,12 @@ class ColonySimulation:
             position = cellmodeller_properties[c][3]
             x, y = _scene_position(position, self.scene_shape)
 
-
-            OPL_cell = raster_cell(cellmodeller_properties[c][0], cellmodeller_properties[c][1], separation=0)
             if as_3D:
-                OPL_cell_3D = convert_to_3D(OPL_cell)
+                OPL_cell = OPL_cells[c]
+                OPL_cell_3D = OPL_cells_3D[c]
                 OPL_cell_3D = np.array([rotate(x, - cellmodeller_properties[c][2], resize=True, clip=False, preserve_range=True) for x in OPL_cell_3D])
+            else:
+                OPL_cell = raster_cell(cellmodeller_properties[c][0], cellmodeller_properties[c][1], separation=0)
             rotated_OPL_cell = rotate(OPL_cell, - (cellmodeller_properties[c][2]), resize=True, clip=False,
                                       preserve_range=True, center=(x, y)).astype(int)
             cell_y, cell_x = (np.array(rotated_OPL_cell.shape) / 2).astype(int)
@@ -176,18 +180,18 @@ class ColonySimulation:
             offset_x = rotated_OPL_cell.shape[1] - space[y - cell_y:y + cell_y, x - cell_x:x + cell_x].shape[1]
 
             if as_3D:
+                z_start = (n_layers - OPL_cell_3D.shape[0]) // 2
+                volume_slice = np.s_[
+                    z_start:z_start + OPL_cell_3D.shape[0],
+                    y - cell_y:y + cell_y + offset_y,
+                    x - cell_x:x + cell_x + offset_x,
+                ]
                 #OPL_cell_3D = convert_to_3D(rotated_OPL_cell)
                 if FL:
                     FL_cell_3D = np.array([OPL_to_FL(x, density = density*density_modifiers[c]) for x in OPL_cell_3D])
-                    fluorescence_space_3D[:,
-                        y - cell_y:y + cell_y + offset_y,
-                        x - cell_x:x + cell_x + offset_x
-                    ] += FL_cell_3D 
+                    fluorescence_space_3D[volume_slice] += FL_cell_3D
                 
-                space_3D[:,
-                    y - cell_y:y + cell_y + offset_y,
-                    x - cell_x:x + cell_x + offset_x
-                ] += OPL_cell_3D
+                space_3D[volume_slice] += OPL_cell_3D
 
             else:
                 if not as_3D:

--- a/SyMBac/colony_simulation.py
+++ b/SyMBac/colony_simulation.py
@@ -1,6 +1,4 @@
-import CellModeller
 import noise
-from CellModeller.Simulator import Simulator
 import os
 import numpy as np
 from glob import glob
@@ -53,6 +51,13 @@ class ColonySimulation:
             pass
 
     def run_cellmodeller_sim(self, num_sim):
+        try:
+            from CellModeller.Simulator import Simulator
+        except ImportError as error:
+            raise ImportError(
+                "CellModeller is required for ColonySimulation.run_cellmodeller_sim"
+            ) from error
+
         for n in range(num_sim):
             try:
                 os.mkdir(f"data/{self.save_dir}")
@@ -249,4 +254,3 @@ class ColonySimulation:
         n_files = len(glob("data/scenes/*.png"))
         zero_pads = np.ceil(np.log10(len(self.pickles_flat))).astype(int) + 2
         Parallel(n_jobs=n_jobs)(delayed(self.draw_scene)(_, True, str(i+1+n_files).zfill(zero_pads), False, FL, density, random_distribution, distribution_args, as_3D, crop, crop_pad) for i, _ in tqdm(enumerate(all_cellmodeller_properties), desc='Scene Draw:'))
-

--- a/SyMBac/drawing.py
+++ b/SyMBac/drawing.py
@@ -64,7 +64,8 @@ def apply_cell_texture(OPL_cell, cell_id, scale=70.0, octaves=3, persistence=0.5
 def get_crop_bounds_2D(img, tol=0):
     mask = img>tol
     x_idx = np.ix_(mask.any(1),mask.any(0))
-    start_row, stop_row, start_col, stop_col = x_idx[0][0][0], x_idx[0][-1][0], x_idx[1][0][0], x_idx[1][0][-1]
+    start_row, stop_row = x_idx[0][0][0], x_idx[0][-1][0] + 1
+    start_col, stop_col = x_idx[1][0][0], x_idx[1][0][-1] + 1
 
     return (start_row, stop_row), (start_col, stop_col)
 

--- a/SyMBac/renderer.py
+++ b/SyMBac/renderer.py
@@ -125,6 +125,9 @@ def convolve_rescale(image, kernel, rescale_factor, rescale_int):
     output : 2D numpy array
         The output of the convolution rescale operation
     """
+    if np.ndim(image) != 2 or np.ndim(kernel) != 2:
+        raise ValueError("convolve_rescale requires a 2-D image and kernel")
+
     output = _convolve_2d(image, kernel)
     output = rescale(output, rescale_factor, anti_aliasing=False)
 
@@ -714,7 +717,7 @@ class Renderer:
                                      pix_mic_conv=self.simulation.pix_mic_conv, apo_sigma=sigma, mode="phase contrast",
                                      condenser=self.PSF.condenser)
             self.PSF.calculate_PSF()
-        if self.PSF.mode.lower() == "3d fluo":  # Full 3D PSF model
+        if "3d fluo" in self.PSF.mode.lower():  # Full 3D PSF model
             def generate_deviation_from_CL(centreline, thickness):
                 return np.arange(thickness) + centreline - int(np.ceil(thickness / 2))
 

--- a/tests/test_colony_optional_dependencies.py
+++ b/tests/test_colony_optional_dependencies.py
@@ -1,0 +1,31 @@
+import sys
+
+import pytest
+
+
+def test_colony_modules_import_without_optional_dependencies():
+    from SyMBac.colony_renderer import ColonyRenderer
+    from SyMBac.colony_simulation import ColonySimulation
+
+    assert ColonyRenderer.__name__ == "ColonyRenderer"
+    assert ColonySimulation.__name__ == "ColonySimulation"
+
+
+def test_cellmodeller_is_required_only_when_simulation_is_run(monkeypatch):
+    from SyMBac.colony_simulation import ColonySimulation
+
+    monkeypatch.setitem(sys.modules, "CellModeller", None)
+    simulation = ColonySimulation.__new__(ColonySimulation)
+
+    with pytest.raises(ImportError, match="CellModeller.*run_cellmodeller_sim"):
+        simulation.run_cellmodeller_sim(1)
+
+
+def test_ray_is_required_only_for_ray_generation(monkeypatch):
+    from SyMBac.colony_renderer import ColonyRenderer
+
+    monkeypatch.setitem(sys.modules, "ray", None)
+    renderer = ColonyRenderer.__new__(ColonyRenderer)
+
+    with pytest.raises(ImportError, match="Ray.*generate_random_samples_ray"):
+        renderer.generate_random_samples_ray(1, 0, "unused")

--- a/tests/test_colony_rendering.py
+++ b/tests/test_colony_rendering.py
@@ -1,0 +1,168 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from SyMBac import colony_renderer, colony_simulation
+from SyMBac.colony_renderer import ColonyRenderer
+from SyMBac.colony_simulation import ColonySimulation
+from SyMBac.renderer import convolve_rescale
+
+
+def _write_png(path, value):
+    Image.fromarray(np.full((3, 3), value, dtype=np.uint8)).save(path)
+
+
+def _simulation_paths(tmp_path):
+    paths = {}
+    for name in ("masks", "opl", "fluorescence", "fluorescence_3d"):
+        paths[name] = tmp_path / name
+        paths[name].mkdir()
+    return paths
+
+
+def test_float_images_are_scaled_to_uint16_for_png():
+    image = np.array([[-2.0, 0.0, 2.0]], dtype=np.float32)
+
+    converted = colony_renderer._as_png_uint16(image)
+
+    assert converted.dtype == np.uint16
+    np.testing.assert_array_equal(converted, [[0, 32768, 65535]])
+
+
+def test_label_composition_preserves_labels_and_single_pixel_cells():
+    mask = np.array([[0, 0], [0, 1]], dtype=np.uint16)
+    cell_pixels = np.array([[True, True], [False, False]])
+
+    composed = colony_simulation._compose_label_mask(mask, cell_pixels, 2)
+
+    np.testing.assert_array_equal(composed, [[2, 2], [0, 1]])
+    assert set(np.unique(composed)) == {0, 1, 2}
+
+
+def test_rectangular_scene_uses_independent_axis_offsets():
+    x, y = colony_simulation._scene_position(position=(-4, 1), scene_shape=(7, 11))
+
+    assert (x, y) == (2, 5)
+
+
+def test_simple_fluorescence_reads_fluorescence_scenes(tmp_path):
+    paths = _simulation_paths(tmp_path)
+    _write_png(paths["opl"] / "opl.png", 1)
+    _write_png(paths["fluorescence"] / "fluorescence.png", 2)
+    simulation = SimpleNamespace(
+        scene_shape=(3, 3),
+        resize_amount=1,
+        masks_dir=str(paths["masks"]),
+        OPL_dir=str(paths["opl"]),
+        fluorescence_dir=str(paths["fluorescence"]),
+        fluorescent_projections_dir=str(paths["fluorescence_3d"]),
+    )
+
+    renderer = ColonyRenderer(
+        simulation=simulation,
+        PSF=SimpleNamespace(mode="simple fluo"),
+    )
+
+    assert renderer.OPL_dirs == [str(paths["fluorescence"] / "fluorescence.png")]
+
+
+def test_serial_generation_uses_output_indices_and_writes_valid_pngs(
+    tmp_path, monkeypatch
+):
+    paths = _simulation_paths(tmp_path)
+    for index in range(2):
+        _write_png(paths["opl"] / f"{index}.png", index)
+        _write_png(paths["masks"] / f"{index}.png", index + 1)
+    simulation = SimpleNamespace(
+        scene_shape=(3, 3),
+        resize_amount=1,
+        masks_dir=str(paths["masks"]),
+        OPL_dir=str(paths["opl"]),
+        fluorescence_dir=str(paths["fluorescence"]),
+        fluorescent_projections_dir=str(paths["fluorescence_3d"]),
+    )
+    renderer = ColonyRenderer(
+        simulation=simulation,
+        PSF=SimpleNamespace(mode="phase contrast"),
+    )
+    monkeypatch.setattr(
+        renderer,
+        "render_scene",
+        lambda index: np.array([[-2.0, 0.0, 2.0]], dtype=np.float32),
+    )
+
+    output_dir = tmp_path / "output"
+    renderer.generate_random_samples(3, roll_prob=0, savedir=output_dir, n_jobs=1)
+
+    images = sorted((output_dir / "synth_imgs").glob("*.png"))
+    masks = sorted((output_dir / "masks").glob("*.png"))
+    assert [path.name for path in images] == ["0.png", "1.png", "2.png"]
+    assert [path.name for path in masks] == ["0.png", "1.png", "2.png"]
+    assert np.asarray(Image.open(images[0])).dtype == np.uint16
+
+
+def test_draw_scene_returns_cropped_3d_volume_and_retains_thin_mask(
+    monkeypatch,
+):
+    cell = np.zeros((3, 3), dtype=float)
+    cell[1, 1] = 1
+    volume = np.stack([cell, cell * 2])
+    monkeypatch.setattr(colony_simulation, "raster_cell", lambda *args, **kwargs: cell)
+    monkeypatch.setattr(
+        colony_simulation,
+        "rotate",
+        lambda image, *args, **kwargs: image,
+    )
+    monkeypatch.setattr(colony_simulation, "convert_to_3D", lambda image: volume)
+    monkeypatch.setattr(
+        colony_simulation,
+        "get_crop_bounds_2D",
+        lambda mask: ((3, 6), (1, 4)),
+    )
+    simulation = ColonySimulation.__new__(ColonySimulation)
+    simulation.scene_shape = (7, 11)
+
+    rendered, mask = simulation.draw_scene(
+        [[3, 3, 0, [-4, 0]]],
+        as_3D=True,
+        crop=True,
+    )
+
+    assert rendered.shape == (2, 3, 3)
+    assert mask.shape == (3, 3)
+    assert rendered[:, 1, 1].tolist() == [1, 2]
+    assert mask[1, 1] == 1
+
+
+def test_colony_3d_rendering_normalizes_the_whole_volume(monkeypatch):
+    renderer = ColonyRenderer.__new__(ColonyRenderer)
+    renderer.PSF = SimpleNamespace(
+        mode="3d fluo",
+        kernel=np.stack([np.ones((2, 2)), np.ones((2, 2)) * 3]),
+    )
+    renderer.resize_amount = 1
+    renderer.force_2D = False
+    renderer.OPL_loader = lambda index: np.ones((2, 2, 2))
+    monkeypatch.setattr(
+        colony_renderer,
+        "convolve_rescale",
+        lambda image, kernel, *args, **kwargs: image * kernel.sum(),
+    )
+
+    rendered = renderer.render_scene(0)
+
+    assert rendered.shape == (2, 2, 2)
+    assert rendered[0].mean() == pytest.approx(0)
+    assert rendered[1].mean() == pytest.approx(1)
+
+
+def test_2d_convolution_rejects_3d_kernels():
+    with pytest.raises(ValueError, match="2-D image and kernel"):
+        convolve_rescale(
+            np.ones((3, 3)),
+            np.ones((2, 3, 3)),
+            rescale_factor=1,
+            rescale_int=False,
+        )

--- a/tests/test_colony_rendering.py
+++ b/tests/test_colony_rendering.py
@@ -103,11 +103,8 @@ def test_serial_generation_uses_output_indices_and_writes_valid_pngs(
     assert np.asarray(Image.open(images[0])).dtype == np.uint16
 
 
-def test_draw_scene_returns_cropped_3d_volume_and_retains_thin_mask(
-    monkeypatch,
-):
-    cell = np.zeros((3, 3), dtype=float)
-    cell[1, 1] = 1
+def test_draw_scene_returns_complete_cropped_3d_volume(monkeypatch):
+    cell = np.ones((3, 3), dtype=float)
     volume = np.stack([cell, cell * 2])
     monkeypatch.setattr(colony_simulation, "raster_cell", lambda *args, **kwargs: cell)
     monkeypatch.setattr(
@@ -116,11 +113,6 @@ def test_draw_scene_returns_cropped_3d_volume_and_retains_thin_mask(
         lambda image, *args, **kwargs: image,
     )
     monkeypatch.setattr(colony_simulation, "convert_to_3D", lambda image: volume)
-    monkeypatch.setattr(
-        colony_simulation,
-        "get_crop_bounds_2D",
-        lambda mask: ((3, 6), (1, 4)),
-    )
     simulation = ColonySimulation.__new__(ColonySimulation)
     simulation.scene_shape = (7, 11)
 
@@ -134,6 +126,40 @@ def test_draw_scene_returns_cropped_3d_volume_and_retains_thin_mask(
     assert mask.shape == (3, 3)
     assert rendered[:, 1, 1].tolist() == [1, 2]
     assert mask[1, 1] == 1
+
+
+def test_draw_scene_centers_cells_with_different_3d_depths(monkeypatch):
+    small_cell = np.ones((3, 3), dtype=float)
+    large_cell = np.ones((5, 3), dtype=float)
+
+    def raster_cell(length, *args, **kwargs):
+        return small_cell if length == 3 else large_cell
+
+    def convert_to_3d(cell):
+        depth = 2 if cell.shape[0] == 3 else 4
+        return np.repeat(cell[None], depth, axis=0)
+
+    monkeypatch.setattr(colony_simulation, "raster_cell", raster_cell)
+    monkeypatch.setattr(
+        colony_simulation,
+        "rotate",
+        lambda image, *args, **kwargs: image,
+    )
+    monkeypatch.setattr(colony_simulation, "convert_to_3D", convert_to_3d)
+    simulation = ColonySimulation.__new__(ColonySimulation)
+    simulation.scene_shape = (9, 15)
+
+    rendered, _ = simulation.draw_scene(
+        [
+            [3, 3, 0, [-3, 0]],
+            [5, 3, 0, [3, 0]],
+        ],
+        as_3D=True,
+    )
+
+    assert rendered.shape == (4, 9, 15)
+    np.testing.assert_array_equal(rendered[:, 5, 5], [0, 1, 1, 0])
+    np.testing.assert_array_equal(rendered[:, 5, 11], [1, 1, 1, 1])
 
 
 def test_colony_3d_rendering_normalizes_the_whole_volume(monkeypatch):

--- a/tests/test_psf_3d.py
+++ b/tests/test_psf_3d.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+
+from SyMBac import PSF
+from SyMBac.PSF import PSF_generator
+
+
+def test_3d_psf_defaults_working_distance_before_calling_psfmodels(monkeypatch):
+    received = {}
+
+    def make_psf(**kwargs):
+        received.update(kwargs)
+        return np.ones((kwargs["z"], kwargs["nx"], kwargs["nx"]))
+
+    monkeypatch.setattr(PSF.psfm, "make_psf", make_psf)
+    generator = PSF_generator(
+        radius=1,
+        wavelength=0.6,
+        NA=1.2,
+        n=1.3,
+        apo_sigma=1,
+        mode="3d fluo",
+        z_height=3,
+        scale=0.1,
+    )
+
+    generator.calculate_PSF()
+
+    assert received["ti0"] == 150.0
+
+
+@pytest.mark.parametrize("working_distance", [0, -1, np.nan])
+def test_3d_psf_rejects_invalid_working_distance(working_distance):
+    with pytest.raises(ValueError, match="working_distance"):
+        PSF_generator(
+            radius=1,
+            wavelength=0.6,
+            NA=1.2,
+            n=1.3,
+            apo_sigma=1,
+            mode="3d fluo",
+            z_height=3,
+            scale=0.1,
+            working_distance=working_distance,
+        )


### PR DESCRIPTION
## What changed

- defer Ray and CellModeller imports until their dependent methods are called, with feature-specific errors
- write 2-D float renders as scaled 16-bit PNGs and use unique output indices
- load simple fluorescence scenes from the fluorescence directory
- compose instance masks by assignment so overlaps do not create synthetic labels and one-pixel cells remain labeled
- use independent x/y offsets for rectangular scenes
- return and crop the actual 3-D colony volume, including mixed-depth cells
- default and validate 3-D PSF working distance, and reject 3-D kernels at the 2-D convolution boundary
- preserve the z axis during colony rendering and normalize the completed volume globally

## Why

The retained legacy colony paths failed to import unless Ray and CellModeller were installed, and several rendering branches could overwrite samples, lose labels or crop boundaries, return blank data, or mishandle 3-D shapes and normalization. Ray and CellModeller remain optional; this PR does not add heavyweight integration tests or dependencies.

## Validation

- `pixi run pytest -q tests/test_colony_optional_dependencies.py tests/test_colony_rendering.py tests/test_psf_3d.py tests/test_renderer_mask_export.py tests/test_colony_overlap.py` — 19 passed
- `pixi run pytest -q` — 79 passed, with the existing GPU-backend fallback warning