### PR TITLE
Add Chromatix thin-phase sample core

### DIFF
--- a/SyMBac/brightfield.py
+++ b/SyMBac/brightfield.py
@@ -1,0 +1,179 @@
+"""Thin phase sample for the SyMBac brightfield path.
+
+Two steps live here. ``scene_to_thickness_um`` turns a SyMBac scene into
+micrometres, and ``apply_thin_phase_sample`` puts that thickness onto a
+Chromatix vector field as a thin, isotropic, non-absorbing sample.
+
+Both stop at the field immediately after the sample. There is no propagation,
+objective, pupil, camera or detector here, so the field that comes back is not
+a brightfield image.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["scene_to_thickness_um", "apply_thin_phase_sample"]
+
+
+def _import_chromatix():
+    """Import JAX and Chromatix, which this project ships only for Python 3.12."""
+    # Imported here rather than at the top of the module so that importing
+    # SyMBac.brightfield, and using the NumPy-only conversion below, still
+    # works on the interpreters where JAX is not installed.
+    try:
+        import jax.numpy as jnp
+
+        import chromatix.functional as cf
+        from chromatix import VectorField
+    except ImportError as exc:  # pragma: no cover - depends on the environment
+        raise ImportError(
+            "apply_thin_phase_sample requires JAX and Chromatix, which this "
+            "project installs only for Python 3.12. Run it from the Python "
+            "3.12 Pixi environment."
+        ) from exc
+    return cf, jnp, VectorField
+
+
+def _finite_2d_array(values, name):
+    """Return ``values`` as a finite 2D float array, or raise."""
+    array = np.asarray(values, dtype=float)
+    if array.ndim != 2:
+        raise ValueError(
+            f"{name} must be a two-dimensional array, got {array.ndim} "
+            f"dimension(s) with shape {array.shape}."
+        )
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values.")
+    return array
+
+
+def _positive_scale(value, name):
+    """Return ``value`` as a positive finite float, or raise."""
+    try:
+        scale = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"{name} must be a real number, got {type(value).__name__}."
+        ) from exc
+    if not np.isfinite(scale) or scale <= 0.0:
+        raise ValueError(f"{name} must be a positive finite number, got {value!r}.")
+    return scale
+
+
+def scene_to_thickness_um(opl_scene, *, pix_mic_conv_um, resize_amount):
+    """Convert a SyMBac scene into projected thickness in micrometres.
+
+    ``OPL_scene`` is a legacy name. What it holds is projected geometric
+    thickness measured in supersampled simulation pixels, not an optical path
+    length, so this is only a change of units: one supersampled pixel is
+    ``pix_mic_conv_um / resize_amount`` micrometres. Refractive-index contrast
+    does not belong in this step and is not used here.
+
+    Parameters
+    ----------
+    opl_scene : array_like
+        2D scene of projected thickness, in supersampled simulation pixels.
+        Must be finite and non-negative.
+    pix_mic_conv_um : float
+        Pixel size of the final, non-supersampled image, in micrometres per
+        pixel. Must be positive.
+    resize_amount : float
+        Supersampling factor of the simulation, dimensionless. Must be
+        positive.
+
+    Returns
+    -------
+    numpy.ndarray
+        Thickness in micrometres, same shape as ``opl_scene``. This is a new
+        array, so the input is left untouched.
+    """
+    scene = _finite_2d_array(opl_scene, "opl_scene")
+    if np.any(scene < 0.0):
+        raise ValueError(
+            "opl_scene must be non-negative because it is a projected thickness."
+        )
+    pixel_size_um = _positive_scale(pix_mic_conv_um, "pix_mic_conv_um")
+    supersampling = _positive_scale(resize_amount, "resize_amount")
+    return scene * pixel_size_um / supersampling
+
+
+def apply_thin_phase_sample(field, thickness_um, *, refractive_index_difference):
+    """Apply a thin, isotropic, pure-phase sample to a Chromatix vector field.
+
+    The sample multiplies the field by ``exp(1j * phase_rad)``, where
+
+    ``phase_rad = 2 * pi * refractive_index_difference * thickness_um /
+    wavelength_vacuum_um``
+
+    That factor has modulus one, so the sample is non-absorbing, and the same
+    real phase reaches all three components, so intensity, power and
+    polarization come out unchanged. The vacuum wavelength is taken from the
+    field itself, which means it cannot disagree with the field the phase is
+    applied to.
+
+    Parameters
+    ----------
+    field : chromatix.VectorField
+        Monochromatic Chromatix vector field, components ordered ``[z, y, x]``.
+    thickness_um : array_like
+        2D projected thickness in micrometres, with the same spatial shape as
+        ``field``. Must be finite and non-negative.
+    refractive_index_difference : float
+        Refractive-index contrast between sample and surrounding medium,
+        dimensionless. May be negative, and must be finite.
+
+    Returns
+    -------
+    chromatix.VectorField
+        A new field immediately after the sample, same spatial shape and same
+        ``[z, y, x]`` component order. Neither input is modified.
+    """
+    cf, jnp, VectorField = _import_chromatix()
+
+    if not isinstance(field, VectorField):
+        raise TypeError(
+            "field must be a monochromatic Chromatix VectorField, got "
+            f"{type(field).__name__}."
+        )
+
+    thickness = _finite_2d_array(thickness_um, "thickness_um")
+    if np.any(thickness < 0.0):
+        raise ValueError("thickness_um must be non-negative.")
+
+    if tuple(field.spatial_shape) != thickness.shape:
+        raise ValueError(
+            "thickness_um and field must have the same spatial shape, got "
+            f"{thickness.shape} and {tuple(field.spatial_shape)}."
+        )
+
+    try:
+        delta_n = float(refractive_index_difference)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            "refractive_index_difference must be a real number, got "
+            f"{type(refractive_index_difference).__name__}."
+        ) from exc
+    if not np.isfinite(delta_n):
+        raise ValueError(
+            "refractive_index_difference must be finite, got "
+            f"{refractive_index_difference!r}."
+        )
+
+    # Read the wavelength from the field instead of taking it as an argument.
+    wavelengths_um = np.asarray(field.spectrum.wavelength, dtype=float).reshape(-1)
+    if wavelengths_um.size != 1:
+        raise ValueError(
+            f"field must be monochromatic, got {wavelengths_um.size} wavelengths."
+        )
+    wavelength_vacuum_um = float(wavelengths_um[0])
+    if not np.isfinite(wavelength_vacuum_um) or wavelength_vacuum_um <= 0.0:
+        raise ValueError(
+            "the vacuum wavelength read from field must be positive and finite, "
+            f"got {wavelength_vacuum_um!r} um."
+        )
+
+    phase_rad = 2 * np.pi * delta_n * thickness / wavelength_vacuum_um
+    # The phase is already worked out for this one wavelength, so Chromatix
+    # should not rescale it again: spectrally_modulate stays off.
+    return cf.phase_change(field, jnp.asarray(phase_rad), spectrally_modulate=False)

--- a/tests/test_brightfield.py
+++ b/tests/test_brightfield.py
@@ -1,0 +1,349 @@
+"""Tests for the thin phase sample core in ``SyMBac.brightfield``.
+
+The whole file skips if JAX and Chromatix are missing, since the project only
+installs them for Python 3.12. They are there in the 3.12 Pixi environment, so
+these tests run rather than skip.
+"""
+
+import numpy as np
+import pytest
+
+jnp = pytest.importorskip(
+    "jax.numpy",
+    reason="JAX is installed only for Python 3.12 in this project.",
+)
+cf = pytest.importorskip(
+    "chromatix.functional",
+    reason="Chromatix is installed only for Python 3.12 in this project.",
+)
+
+from chromatix import VectorField  # noqa: E402  (imported after the skip guard)
+
+from SyMBac.brightfield import (  # noqa: E402  (imported after the skip guard)
+    apply_thin_phase_sample,
+    scene_to_thickness_um,
+)
+from SyMBac.drawing import draw_scene_from_segments  # noqa: E402
+
+WAVELENGTH_UM = 0.532
+DX_UM = 0.25
+PIX_MIC_CONV_UM = 0.065
+RESIZE_AMOUNT = 3
+DELTA_N = 0.05
+
+
+def _vector_plane_wave(shape=(8, 8), amplitude=None, wavelength_um=WAVELENGTH_UM):
+    """Small monochromatic vector plane wave, components ``[z, y, x]``."""
+    if amplitude is None:
+        amplitude = cf.linear(0.0)  # [E_z, E_y, E_x] = [0, 0, 1]
+    return cf.plane_wave(
+        shape, DX_UM, wavelength_um, amplitude=amplitude, scalar=False
+    )
+
+
+def _expected_phase_rad(thickness_um, refractive_index_difference, wavelength_um=WAVELENGTH_UM):
+    """Expected phase, worked out here so the test does not reuse the code."""
+    return (
+        2
+        * np.pi
+        * refractive_index_difference
+        * np.asarray(thickness_um, dtype=float)
+        / wavelength_um
+    )
+
+
+# Task point 1: one supersampled pixel is pix_mic_conv_um / resize_amount
+# micrometres, and neither axis gets swapped.
+def test_scene_converts_per_supersampled_pixel_without_transposing_axes():
+    scene = np.arange(6, dtype=float).reshape(2, 3)
+
+    thickness_um = scene_to_thickness_um(
+        scene, pix_mic_conv_um=PIX_MIC_CONV_UM, resize_amount=RESIZE_AMOUNT
+    )
+
+    np.testing.assert_array_equal(
+        thickness_um, scene * PIX_MIC_CONV_UM / RESIZE_AMOUNT
+    )
+    assert thickness_um.shape == scene.shape == (2, 3)
+
+    micrometres_per_pixel = PIX_MIC_CONV_UM / RESIZE_AMOUNT
+    assert thickness_um[1, 2] == pytest.approx(scene[1, 2] * micrometres_per_pixel)
+
+    marker = np.zeros((2, 3))
+    marker[0, 2] = 7.0
+    converted = scene_to_thickness_um(
+        marker, pix_mic_conv_um=PIX_MIC_CONV_UM, resize_amount=RESIZE_AMOUNT
+    )
+    assert converted[0, 2] == pytest.approx(7.0 * micrometres_per_pixel)
+    assert converted.sum() == pytest.approx(converted[0, 2])
+
+    transposed = scene_to_thickness_um(
+        scene.T, pix_mic_conv_um=PIX_MIC_CONV_UM, resize_amount=RESIZE_AMOUNT
+    )
+    np.testing.assert_array_equal(transposed, thickness_um.T)
+
+
+# Task point 2: a scene from the current draw_scene_from_segments goes
+# through both functions.
+def test_scene_from_draw_scene_from_segments_passes_through_both_functions():
+    cells_segment_data = [
+        {
+            "positions": np.array([[12.0, 10.0], [18.0, 10.0]]),
+            "radii": np.array([4.0, 4.0]),
+            "mask_label": 1,
+            "cell_id": 1,
+        }
+    ]
+
+    scene, _mask = draw_scene_from_segments(cells_segment_data, (20, 30), 0, True)
+    assert scene.shape == (20, 30)
+    assert np.any(scene > 0.0)
+
+    thickness_um = scene_to_thickness_um(
+        scene, pix_mic_conv_um=PIX_MIC_CONV_UM, resize_amount=RESIZE_AMOUNT
+    )
+    field = _vector_plane_wave(shape=scene.shape)
+
+    sampled = apply_thin_phase_sample(
+        field, thickness_um, refractive_index_difference=DELTA_N
+    )
+
+    assert isinstance(sampled, VectorField)
+    assert sampled.u.shape == (20, 30, 3)
+    assert bool(jnp.all(jnp.isfinite(sampled.u)))
+
+
+# Task point 3: check against an input * exp(i * phase) worked out here in
+# the test, not with Chromatix.
+def test_field_matches_independent_exp_i_phase_calculation():
+    shape = (4, 6)
+    thickness_um = np.linspace(0.0, 1.2, num=24).reshape(shape)
+    field = _vector_plane_wave(shape)
+
+    sampled = apply_thin_phase_sample(
+        field, thickness_um, refractive_index_difference=DELTA_N
+    )
+
+    phase_rad = _expected_phase_rad(thickness_um, DELTA_N)
+    expected_u = np.asarray(field.u) * np.exp(1j * phase_rad)[..., np.newaxis]
+    np.testing.assert_allclose(
+        np.asarray(sampled.u), expected_u, rtol=1e-6, atol=1e-7
+    )
+
+
+# Task point 4: all three components get the same phase, so the
+# polarization does not move.
+def test_every_component_receives_the_same_phase_so_polarisation_is_unchanged():
+    shape = (4, 4)
+    amplitude = cf.linear(np.pi / 4)  # [0, E_y, E_x] with both transverse parts non-zero
+    assert float(jnp.abs(amplitude[1])) > 0.1
+    assert float(jnp.abs(amplitude[2])) > 0.1
+
+    field = _vector_plane_wave(shape, amplitude=amplitude)
+    thickness_um = np.full(shape, 0.8)
+
+    sampled = apply_thin_phase_sample(
+        field, thickness_um, refractive_index_difference=DELTA_N
+    )
+
+    ratio_y = np.asarray(sampled.u[..., 1]) / np.asarray(field.u[..., 1])
+    ratio_x = np.asarray(sampled.u[..., 2]) / np.asarray(field.u[..., 2])
+    np.testing.assert_allclose(ratio_y, ratio_x, rtol=1e-6)
+    np.testing.assert_allclose(
+        np.angle(ratio_x),
+        _expected_phase_rad(thickness_um, DELTA_N),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+    polarisation_before = np.asarray(field.u[..., 1]) / np.asarray(field.u[..., 2])
+    polarisation_after = np.asarray(sampled.u[..., 1]) / np.asarray(sampled.u[..., 2])
+    np.testing.assert_allclose(polarisation_after, polarisation_before, rtol=1e-6)
+
+
+# Task point 5: no thickness or no index contrast means no change.
+def test_zero_thickness_or_zero_index_difference_leaves_field_unchanged():
+    shape = (4, 4)
+    field = _vector_plane_wave(shape, amplitude=cf.linear(np.pi / 4))
+
+    zero_thickness = apply_thin_phase_sample(
+        field, np.zeros(shape), refractive_index_difference=DELTA_N
+    )
+    np.testing.assert_allclose(
+        np.asarray(zero_thickness.u), np.asarray(field.u), rtol=0.0, atol=0.0
+    )
+
+    zero_contrast = apply_thin_phase_sample(
+        field, np.full(shape, 0.8), refractive_index_difference=0.0
+    )
+    np.testing.assert_allclose(
+        np.asarray(zero_contrast.u), np.asarray(field.u), rtol=0.0, atol=0.0
+    )
+
+
+# Task point 6: a pure phase sample keeps intensity and power.
+def test_pure_phase_sample_preserves_intensity_and_power():
+    shape = (8, 8)
+    field = _vector_plane_wave(shape, amplitude=cf.linear(np.pi / 3))
+    thickness_um = np.linspace(0.0, 1.5, num=64).reshape(shape)
+
+    sampled = apply_thin_phase_sample(
+        field, thickness_um, refractive_index_difference=DELTA_N
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(sampled.intensity), np.asarray(field.intensity), rtol=1e-6, atol=1e-9
+    )
+    np.testing.assert_allclose(
+        np.asarray(sampled.power), np.asarray(field.power), rtol=1e-6, atol=1e-9
+    )
+
+
+# Task point 7: type, shape, [z, y, x] components, finite values, and the
+# inputs left untouched.
+def test_output_type_shape_components_and_input_immutability():
+    shape = (5, 7)
+    field = _vector_plane_wave(shape)
+    thickness_um = np.full(shape, 0.8)
+
+    thickness_before = thickness_um.copy()
+    u_before = np.asarray(field.u).copy()
+
+    sampled = apply_thin_phase_sample(
+        field, thickness_um, refractive_index_difference=DELTA_N
+    )
+
+    assert isinstance(sampled, VectorField)
+    assert sampled.u.shape == (5, 7, 3)
+    assert tuple(sampled.spatial_shape) == shape
+    assert bool(jnp.all(jnp.isfinite(sampled.u)))
+
+    # the input is x-polarised, so in [z, y, x] order only the last component
+    # carries amplitude and the leading z component stays exactly zero.
+    assert float(jnp.max(jnp.abs(sampled.u[..., 0]))) == 0.0
+    assert float(jnp.max(jnp.abs(sampled.u[..., 1]))) == 0.0
+    assert float(jnp.max(jnp.abs(sampled.u[..., 2]))) > 0.0
+
+    np.testing.assert_array_equal(thickness_um, thickness_before)
+    np.testing.assert_array_equal(np.asarray(field.u), u_before)
+
+
+# Extra: the wavelength really does come from the field, not an argument.
+def test_phase_uses_the_wavelength_stored_in_the_field():
+    shape = (4, 4)
+    thickness_um = np.full(shape, 0.8)
+
+    for wavelength_um in (0.405, 0.532, 0.660):
+        field = _vector_plane_wave(shape, wavelength_um=wavelength_um)
+        sampled = apply_thin_phase_sample(
+            field, thickness_um, refractive_index_difference=DELTA_N
+        )
+        ratio = np.asarray(sampled.u[..., 2]) / np.asarray(field.u[..., 2])
+        np.testing.assert_allclose(
+            np.angle(ratio),
+            _expected_phase_rad(thickness_um, DELTA_N, wavelength_um=wavelength_um),
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+
+def test_refractive_index_difference_may_be_negative():
+    shape = (4, 4)
+    field = _vector_plane_wave(shape)
+    thickness_um = np.full(shape, 0.8)
+
+    sampled = apply_thin_phase_sample(
+        field, thickness_um, refractive_index_difference=-DELTA_N
+    )
+
+    ratio = np.asarray(sampled.u[..., 2]) / np.asarray(field.u[..., 2])
+    np.testing.assert_allclose(
+        np.angle(ratio),
+        _expected_phase_rad(thickness_um, -DELTA_N),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        np.asarray(sampled.intensity), np.asarray(field.intensity), rtol=1e-6, atol=1e-9
+    )
+
+
+# Task point 8: bad input has to fail with a clear message.
+@pytest.mark.parametrize(
+    "scene, message",
+    [
+        (np.zeros((2, 2, 2)), "two-dimensional"),
+        (np.zeros(4), "two-dimensional"),
+        (np.array([[0.0, np.nan]]), "finite"),
+        (np.array([[0.0, np.inf]]), "finite"),
+        (np.array([[0.0, -1.0]]), "non-negative"),
+    ],
+)
+def test_invalid_scene_raises(scene, message):
+    with pytest.raises(ValueError, match=message):
+        scene_to_thickness_um(
+            scene, pix_mic_conv_um=PIX_MIC_CONV_UM, resize_amount=RESIZE_AMOUNT
+        )
+
+
+@pytest.mark.parametrize(
+    "pix_mic_conv_um, resize_amount, message",
+    [
+        (0.0, RESIZE_AMOUNT, "pix_mic_conv_um"),
+        (-0.065, RESIZE_AMOUNT, "pix_mic_conv_um"),
+        (np.nan, RESIZE_AMOUNT, "pix_mic_conv_um"),
+        (PIX_MIC_CONV_UM, 0, "resize_amount"),
+        (PIX_MIC_CONV_UM, -3, "resize_amount"),
+        (PIX_MIC_CONV_UM, np.inf, "resize_amount"),
+    ],
+)
+def test_invalid_scale_values_raise(pix_mic_conv_um, resize_amount, message):
+    with pytest.raises(ValueError, match=message):
+        scene_to_thickness_um(
+            np.ones((2, 2)),
+            pix_mic_conv_um=pix_mic_conv_um,
+            resize_amount=resize_amount,
+        )
+
+
+@pytest.mark.parametrize(
+    "thickness_um, message",
+    [
+        (np.zeros((2, 2, 2)), "two-dimensional"),
+        (np.array([[0.0, np.nan], [0.0, 0.0]]), "finite"),
+        (np.array([[0.0, -0.5], [0.0, 0.0]]), "non-negative"),
+    ],
+)
+def test_invalid_thickness_map_raises(thickness_um, message):
+    field = _vector_plane_wave((2, 2))
+    with pytest.raises(ValueError, match=message):
+        apply_thin_phase_sample(
+            field, thickness_um, refractive_index_difference=DELTA_N
+        )
+
+
+@pytest.mark.parametrize("refractive_index_difference", [np.nan, np.inf, -np.inf])
+def test_non_finite_refractive_index_difference_raises(refractive_index_difference):
+    field = _vector_plane_wave((4, 4))
+    with pytest.raises(ValueError, match="refractive_index_difference must be finite"):
+        apply_thin_phase_sample(
+            field,
+            np.zeros((4, 4)),
+            refractive_index_difference=refractive_index_difference,
+        )
+
+
+def test_field_and_thickness_shape_mismatch_raises():
+    field = _vector_plane_wave((4, 4))
+    with pytest.raises(ValueError, match="same spatial shape"):
+        apply_thin_phase_sample(
+            field, np.zeros((4, 5)), refractive_index_difference=DELTA_N
+        )
+
+
+def test_scalar_field_is_rejected():
+    scalar_field = cf.plane_wave((4, 4), DX_UM, WAVELENGTH_UM)
+    with pytest.raises(TypeError, match="VectorField"):
+        apply_thin_phase_sample(
+            scalar_field, np.zeros((4, 4)), refractive_index_difference=DELTA_N
+        )


### PR DESCRIPTION
This adds the physical specimen input and the vector-field sample interaction as package code. It stops at the field immediately after the sample: the returned object is a Chromatix `VectorField`, not a brightfield image.

Two new files, no existing file touched:

- `SyMBac/brightfield.py`
- `tests/test_brightfield.py`

## What each function does

### `scene_to_thickness_um(opl_scene, *, pix_mic_conv_um, resize_amount)`

Converts a SyMBac scene into projected sample thickness in micrometres:

```
thickness_um = opl_scene * pix_mic_conv_um / resize_amount
```

Despite its legacy name, `OPL_scene` holds projected geometric thickness measured in supersampled simulation pixels, not an optical path length, so this is a pure change of units and no refractive-index contrast enters it. The scene must be two-dimensional, finite and non-negative, and both scale factors must be positive and finite. The shape is preserved, a new `float64` array is returned, and the input is not modified. This function is pure NumPy and needs neither JAX nor Chromatix.

### `apply_thin_phase_sample(field, thickness_um, *, refractive_index_difference)`

Applies that thickness map to one monochromatic Chromatix `VectorField` as a thin, isotropic, non-absorbing (pure-phase) sample:

```
phase_rad = 2 * pi * refractive_index_difference * thickness_um / wavelength_vacuum_um
```

The vacuum wavelength is read from the field itself, so there is no second wavelength argument that could disagree with the field it is applied to. The transmittance `exp(1j * phase_rad)` has unit modulus everywhere, and the same real phase reaches all three components, so intensity, power and polarization are unchanged. The function requires the field and the thickness map to share a spatial shape, requires a finite (possibly negative) refractive-index difference, and returns a new `VectorField` with the same spatial shape and the same `[z, y, x]` component order.

JAX and Chromatix are imported inside the call rather than at module import time, because this project installs them only for Python 3.12. Nothing in the module executes on import, and neither function plots, prints, writes files nor normalizes anything.

## Units

| Quantity | Unit |
| --- | --- |
| `opl_scene` | projected thickness, in supersampled simulation pixels |
| `pix_mic_conv_um` | micrometres per pixel of the final, non-supersampled image |
| `resize_amount` | dimensionless supersampling factor |
| `thickness_um` | micrometres |
| `refractive_index_difference` | dimensionless, may be signed |
| vacuum wavelength read from the field | micrometres |
| `phase_rad` | radians |

## Chromatix function used

`chromatix.functional.phase_change`, called as

```python
cf.phase_change(field, jnp.asarray(phase_rad), spectrally_modulate=False)
```

The phase is already calculated for the single field wavelength, so the spectral-modulation choice is made explicit instead of relying on the default. `cf.thin_sample` is not used: in pinned Chromatix 0.6.0 it is documented for scalar fields, whereas this production path stays vectorial. In pinned 0.6.0 `phase_change` broadcasts the 2D phase to `(y, x, 1)` and returns `field * exp(1j * phase)`, so one real phase reaches all three components. The production code never multiplies the field by `exp(i * phase)` by hand; that independent calculation exists only in the test.

## Tests

`tests/test_brightfield.py` skips cleanly when JAX or Chromatix are unavailable, via `pytest.importorskip` at module level, and runs in the Python 3.12 Pixi environment. It covers:

1. an asymmetric, non-square scene converted at exactly `pix_mic_conv_um / resize_amount` micrometres per supersampled pixel, with shape preserved and neither axis transposed;
2. a small scene from the current `draw_scene_from_segments` passing through both functions;
3. the resulting complex field against an independent `input_field * exp(i * phase_rad)` calculation;
4. a vector plane wave with both transverse components non-zero receiving the same scalar phase on every component, leaving the component ratio, i.e. the polarization, unchanged;
5. zero thickness and zero refractive-index difference leaving the field unchanged;
6. `VectorField.intensity` and `Field.power` preserved by the pure-phase sample;
7. output type, spatial shape, `[z, y, x]` component dimension, finite values and input immutability, for both the field and the thickness array;
8. clear errors for non-two-dimensional, non-finite or negative scenes and thickness maps, non-positive or non-finite scale values, a non-finite refractive-index difference, a field/thickness shape mismatch, and a scalar field.

Two further tests check that the phase follows the wavelength stored in the field (0.405, 0.532 and 0.660 µm) and that a negative refractive-index difference produces a negative phase without changing the intensity.

### Test commands and results

```
$ pixi run pytest tests/test_brightfield.py -q
28 passed in 64.84s

$ pixi run pytest -q
91 passed, 1 warning in 130.56s
```

The full suite was 63 passed with the same single warning before this branch, so the 28 new tests are additive and nothing existing changed. The warning is the pre-existing CPU-fallback notice from `SyMBac/renderer.py:55` (no GPU backend on this machine).

`git diff --check` and `git diff --cached --check` are both clean.

## AI assistance

An AI coding assistant was used to draft `SyMBac/brightfield.py` and `tests/test_brightfield.py`.

## Not part of this PR

Propagation away from the sample, an objective, pupil or camera relay, defocus, partial coherence, multiple wavelengths, two-state unpolarized illumination, detector sampling, photons or noise, a scalar production mode, `Renderer` integration, figures, notebooks or example images, and performance optimization. PR #68 is untouched.
